### PR TITLE
Cache dependencies in GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
This patch adds a step for caching dependencies. 

ref: https://github.com/Swatinem/rust-cache