### PR TITLE
fix: addes exec method to Runnable trait and exec impl to DummyVM

### DIFF
--- a/compiler/erg_common/traits.rs
+++ b/compiler/erg_common/traits.rs
@@ -298,9 +298,7 @@ pub trait ImmutableStream<T>: Sized {
 
 // for Runnable::run
 fn expect_block(src: &str) -> bool {
-    src.ends_with(&['=', ':'])
-        || src.ends_with("->")
-        || src.ends_with("=>")
+    src.ends_with(&['=', ':']) || src.ends_with("->") || src.ends_with("=>")
 }
 
 /// this trait implements REPL (Read-Eval-Print-Loop) automatically
@@ -313,6 +311,7 @@ pub trait Runnable: Sized {
     fn finish(&mut self); // called when the :exit command is received.
     fn clear(&mut self);
     fn eval(&mut self, src: Str) -> Result<String, Self::Errs>;
+    fn exec(&mut self, src: Str) -> Result<String, Self::Errs>;
 
     fn ps1(&self) -> String {
         ">>> ".to_string()
@@ -330,7 +329,7 @@ pub trait Runnable: Sized {
         let mut instance = Self::new(cfg);
         let res = match instance.input() {
             Input::File(_) | Input::Pipe(_) | Input::Str(_) => {
-                match instance.eval(instance.input().read()) {
+                match instance.exec(instance.input().read()) {
                     Ok(s) => {
                         println!("{s}");
                         Ok(())

--- a/compiler/erg_compiler/compile.rs
+++ b/compiler/erg_compiler/compile.rs
@@ -134,6 +134,10 @@ impl Runnable for Compiler {
         let codeobj = self.compile(src, "eval")?;
         Ok(codeobj.code_info())
     }
+
+    fn exec(&mut self, _src: Str) -> Result<String, CompileErrors> {
+        unimplemented!("exec is not implemented for CompilerRunner")
+    }
 }
 
 impl Compiler {

--- a/compiler/erg_parser/lex.rs
+++ b/compiler/erg_parser/lex.rs
@@ -55,6 +55,10 @@ impl Runnable for LexerRunner {
                 .to_string())
         }
     }
+
+    fn exec(&mut self, _src: Str) -> Result<String, Self::Errs> {
+        unimplemented!("exec is not implemented for LexerRunner")
+    }
 }
 
 /// Lexes a source code and iterates tokens.

--- a/compiler/erg_parser/parse.rs
+++ b/compiler/erg_parser/parse.rs
@@ -300,6 +300,10 @@ impl Runnable for ParserRunner {
         let ast = self.parse_from_str(src)?;
         Ok(format!("{ast}"))
     }
+
+    fn exec(&mut self, _src: Str) -> Result<String, Self::Errs> {
+        unimplemented!("exec is not implemented for ParserRunner")
+    }
 }
 
 impl ParserRunner {

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -4,7 +4,7 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use erg_common::config::{ErgConfig, Input, BUILD_INFO, SEMVER};
-use erg_common::python_util::exec_py;
+use erg_common::python_util::{eval_pyc, exec_py};
 use erg_common::str::Str;
 use erg_common::traits::Runnable;
 
@@ -42,7 +42,9 @@ impl Runnable for DummyVM {
                     }
                 }
             }
-        } else { None };
+        } else {
+            None
+        };
         Self {
             compiler: Compiler::new(cfg.copy()),
             cfg,
@@ -104,5 +106,11 @@ impl Runnable for DummyVM {
             res.truncate(res.len() - 5);
         }
         Ok(res)
+    }
+
+    fn exec(&mut self, src: Str) -> Result<String, CompileErrors> {
+        self.compiler
+            .compile_and_dump_as_pyc(src, "o.pyc", "eval")?;
+        Ok(eval_pyc("o.pyc"))
     }
 }


### PR DESCRIPTION
Fixes https://github.com/erg-lang/erg/issues/29, which allow for executing `erg` files.