### PR TITLE
feat: switch to pipe mode if piped from stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "erg"
 version = "0.2.5"
 dependencies = [
@@ -14,6 +25,9 @@ dependencies = [
 [[package]]
 name = "erg_common"
 version = "0.2.5"
+dependencies = [
+ "atty",
+]
 
 [[package]]
 name = "erg_compiler"
@@ -29,3 +43,40 @@ version = "0.2.5"
 dependencies = [
  "erg_common",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.132"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/compiler/erg_common/Cargo.toml
+++ b/compiler/erg_common/Cargo.toml
@@ -16,6 +16,7 @@ debug = []
 japanese = []
 
 [dependencies]
+atty = "0.2.14"
 
 [lib]
 path = "lib.rs"

--- a/compiler/erg_common/config.rs
+++ b/compiler/erg_common/config.rs
@@ -143,7 +143,17 @@ pub struct ErgConfig {
 impl Default for ErgConfig {
     #[inline]
     fn default() -> Self {
-        Self::new("exec", 1, false, None, 10, Input::REPL, "<module>", 2)
+        let is_stdin_piped: bool = atty::isnt(atty::Stream::Stdin);
+        let input = if is_stdin_piped {
+            use std::io::Read;
+
+            let mut buffer = String::new();
+            std::io::stdin().read_to_string(&mut buffer).unwrap();
+            Input::Pipe(Str::from(buffer))
+        } else {
+            Input::REPL
+        };
+        Self::new("exec", 1, false, None, 10, input, "<module>", 2)
     }
 }
 


### PR DESCRIPTION
This PR close https://github.com/erg-lang/erg/issues/1.

## Case

on 527afef:
```
$ echo "1 + 2" | cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/erg`
Error[#0000]: File <stdin>, line 1, in <module>
1│ 1 + 2
   ^^^^^
SyntaxError: the evaluation result of the expression is not used
hint: if you don't use the value, use `discard` function
```

on 5267e918 (base branch):
```
$ echo "1 + 2" | cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/erg`
Starting the REPL server...
Connecting to the REPL server...
Retrying to connect to the REPL server...
Erg interpreter 0.2.5 (tags/?:5267e91, 2022/08/17 16:31:29) on x86_64/linux
>>> 3
>>> XXX lineno: 1, opcode: 0
Traceback (most recent call last):
  File "<string>", line 25, in <module>
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.9/importlib/__init__.py", line 169, in reload
    _bootstrap._exec(spec, module)
  File "<frozen importlib._bootstrap>", line 613, in _exec
  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<stdin>", line 1, in <module>
SystemError: unknown opcode

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 28, in <module>
NameError: name 'e' is not defined

>>> 
>>> thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 32, kind: BrokenPipe, message: "Broken pipe" }', src/dummy.rs:69:49
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
