### PR TITLE
Make REPL not show the day of the week on Windows

### DIFF
--- a/compiler/erg_common/datetime.rs
+++ b/compiler/erg_common/datetime.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 pub fn now() -> String {
     let output = if cfg!(windows) {
         Command::new("cmd")
-            .args(&["/C", "echo %date% %time%"])
+            .args(&["/C", "echo %date:~0,10% %time%"])
             .output()
             .expect("failed to execute a process to get current time")
     } else {


### PR DESCRIPTION
Make the output of time on Windows unified with Linux and Mac OS, and fundamentally solve https://github.com/erg-lang/erg/issues/55