### PR TITLE
Allow multiple REPL server at once

### DIFF
--- a/src/scripts/repl_server.py
+++ b/src/scripts/repl_server.py
@@ -6,7 +6,8 @@ import importlib as __importlib
 import io as __io
 
 __server_socket = __socket.socket()
-__server_socket.bind(('0.0.0.0', 8736))
+# DummyVM will replace this __PORT__ with free port
+__server_socket.bind(('127.0.0.1', __PORT__)) 
 __server_socket.listen(1)
 (__client_socket, __client_address) = __server_socket.accept()
 

--- a/src/scripts/repl_server.py
+++ b/src/scripts/repl_server.py
@@ -7,7 +7,7 @@ import io as __io
 
 __server_socket = __socket.socket()
 # DummyVM will replace this __PORT__ with free port
-__server_socket.bind(('127.0.0.1', __PORT__)) 
+__server_socket.bind(('127.0.0.1', __PORT__))
 __server_socket.listen(1)
 (__client_socket, __client_address) = __server_socket.accept()
 


### PR DESCRIPTION
Fixes #85 .
Added procedure that checks whether default port for REPL server(8736) is free.
If not, it just asking OS to allocate free port by bind `TSocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)`.

@mtshiba
