### PR TITLE
Fix a type inference bug for dependent procedural methods

### DIFF
--- a/compiler/erg_compiler/context/compare.rs
+++ b/compiler/erg_compiler/context/compare.rs
@@ -242,6 +242,7 @@ impl Context {
     /// make judgments that include supertypes in the same namespace & take into account glue patches
     /// 同一名前空間にある上位型を含めた判定&接着パッチを考慮した判定を行う
     fn nominal_supertype_of(&self, lhs: &Type, rhs: &Type) -> bool {
+        log!("nominal_supertype_of:\nlhs: {lhs}\nrhs: {rhs}");
         if let Some(res) = self.inquire_cache(rhs, lhs) {
             return res;
         }
@@ -403,7 +404,6 @@ impl Context {
             // true if it can be a supertype, false if it cannot (due to type constraints)
             // No type constraints are imposed here, as subsequent type decisions are made according to the possibilities
             (FreeVar(lfv), rhs) => {
-                log!("{lhs} :>? {rhs}");
                 match &*lfv.borrow() {
                     FreeKind::Linked(t) | FreeKind::UndoableLinked { t, .. } => {
                         self.supertype_of(t, rhs)

--- a/compiler/erg_compiler/context/inquire.rs
+++ b/compiler/erg_compiler/context/inquire.rs
@@ -389,8 +389,8 @@ impl Context {
             ..
         }) = t
         {
-            let receiver_t = callee.receiver_t().unwrap();
-            self.reunify(receiver_t, after, Some(callee.loc()), None)?;
+            log!("{}, {}", callee.ref_t(), after);
+            self.reunify(callee.ref_t(), after, Some(callee.loc()), None)?;
         }
         Ok(())
     }
@@ -876,15 +876,15 @@ impl Context {
         typ: &Type,
     ) -> Option<(&'a Type, &'a Context)> {
         match typ {
-            Type::Refinement(refine) => return self.rec_get_nominal_type_ctx(&refine.t),
-            Type::Quantified(_) => todo!(),
-            Type::PolyClass { name, params } => {
-                if let Some(params_and_ctxs) = self.poly_classes.get(name) {
-                    for (ctx_t, ctx) in params_and_ctxs {
-                        if self.poly_supertype_of(typ, &ctx_t.typarams(), params) {
-                            return Some((ctx_t, ctx));
-                        }
-                    }
+            Type::Refinement(refine) => {
+                return self.rec_get_nominal_type_ctx(&refine.t);
+            }
+            Type::Quantified(_) => {
+                return self.rec_get_nominal_type_ctx(&class("QuantifiedFunction"));
+            }
+            Type::PolyClass { name, params: _ } => {
+                if let Some((t, ctx)) = self.poly_classes.get(name) {
+                    return Some((t, ctx));
                 }
             }
             Type::PolyTrait { name, params: _ } => {

--- a/compiler/erg_compiler/context/mod.rs
+++ b/compiler/erg_compiler/context/mod.rs
@@ -230,6 +230,8 @@ pub struct Context {
     // patchによってsuper class/traitになったものはここに含まれない
     pub(crate) super_classes: Vec<Type>, // if self is a patch, means patch classes
     pub(crate) super_traits: Vec<Type>,  // if self is not a trait, means implemented traits
+    // specialized contexts, If self is a type
+    pub(crate) specializations: Vec<(Type, Context)>,
     /// K: method name, V: impl patch
     /// Provided methods can switch implementations on a scope-by-scope basis
     /// K: メソッド名, V: それを実装するパッチたち
@@ -257,7 +259,7 @@ pub struct Context {
     // Implementation Contexts for Polymorphic Types
     // Vec<TyParam> are specialization parameters
     // e.g. {"Array": [(Array(Nat), ctx), (Array(Int), ctx), (Array(Str), ctx), (Array(Obj), ctx), (Array('T), ctx)], ...}
-    pub(crate) poly_classes: Dict<VarName, Vec<(Type, Context)>>,
+    pub(crate) poly_classes: Dict<VarName, (Type, Context)>,
     // Traits cannot be specialized
     pub(crate) poly_traits: Dict<VarName, (Type, Context)>,
     // patches can be accessed like normal records
@@ -359,6 +361,7 @@ impl Context {
             outer: outer.map(Box::new),
             super_classes,
             super_traits,
+            specializations: vec![],
             const_param_defaults: Dict::default(),
             method_impl_patches: Dict::default(),
             trait_impls: Dict::default(),

--- a/compiler/erg_compiler/context/tyvar.rs
+++ b/compiler/erg_compiler/context/tyvar.rs
@@ -929,7 +929,7 @@ impl Context {
                 }
                 Ok(())
             }
-            (l, r) if self.structural_same_type_of(l, r) => Ok(()),
+            (l, r) if self.rec_same_type_of(l, r) => Ok(()),
             (l, r) => Err(TyCheckError::re_unification_error(
                 line!() as usize,
                 l,

--- a/compiler/erg_compiler/lower.rs
+++ b/compiler/erg_compiler/lower.rs
@@ -11,7 +11,8 @@ use erg_common::{fn_name, log, switch_lang};
 use erg_parser::ast;
 use erg_parser::ast::AST;
 
-use erg_type::constructors::{array, array_mut, class, func, poly_class, proc, quant};
+use erg_type::constructors::{array, array_mut, class, free_var, func, poly_class, proc, quant};
+use erg_type::free::Constraint;
 use erg_type::typaram::TyParam;
 use erg_type::value::ValueObj;
 use erg_type::{HasType, ParamTy, Type};
@@ -136,10 +137,15 @@ impl ASTLowerer {
             }
             new_array.push(elem);
         }
+        let elem_t = if union == Type::Never {
+            free_var(self.ctx.level, Constraint::type_of(Type::Type))
+        } else {
+            union
+        };
         Ok(hir::NormalArray::new(
             array.l_sqbr,
             array.r_sqbr,
-            union,
+            elem_t,
             hir::Args::from(new_array),
         ))
     }

--- a/compiler/erg_type/free.rs
+++ b/compiler/erg_type/free.rs
@@ -145,7 +145,7 @@ impl Constraint {
     }
 
     pub fn type_of(t: Type) -> Self {
-        if &t == &Type::Type {
+        if t == Type::Type {
             Self::sandwiched(Type::Never, Type::Obj, Not)
         } else {
             Self::TypeOf(t)

--- a/compiler/erg_type/lib.rs
+++ b/compiler/erg_type/lib.rs
@@ -965,6 +965,36 @@ pub enum ArgsOwnership {
     VarArgsDefault(Ownership),
 }
 
+impl fmt::Display for ArgsOwnership {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Args {
+                self_,
+                non_defaults,
+                defaults,
+            } => {
+                if let Some(self_) = self_ {
+                    write!(f, "({self_:?}).")?;
+                }
+                write!(f, "(")?;
+                for (i, o) in non_defaults.iter().enumerate() {
+                    if i != 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{o:?}")?;
+                }
+                for o in defaults.iter() {
+                    write!(f, ", {o:?} |= ?")?;
+                }
+                write!(f, ")")?;
+                Ok(())
+            }
+            Self::VarArgs(o) => write!(f, "...{o:?}"),
+            Self::VarArgsDefault(o) => write!(f, "...{o:?} |= ?"),
+        }
+    }
+}
+
 impl ArgsOwnership {
     pub const fn args(
         self_: Option<Ownership>,


### PR DESCRIPTION
Fixed a type inference bug for dependent procedural methods.
This fix will allow `move_check.er` to compile successfully.
