### PR TITLE
Make debug log outputs neater

### DIFF
--- a/compiler/erg_common/traits.rs
+++ b/compiler/erg_common/traits.rs
@@ -8,7 +8,6 @@ use std::process;
 use std::slice::{Iter, IterMut};
 use std::vec::IntoIter;
 
-use crate::color::{GREEN, RESET};
 use crate::config::{ErgConfig, Input, BUILD_DATE, GIT_HASH_SHORT, SEMVER};
 use crate::error::{ErrorDisplay, ErrorKind, Location, MultiErrorDisplay};
 use crate::Str;
@@ -343,7 +342,7 @@ pub trait Runnable: Sized {
             Input::REPL => {
                 let output = stdout();
                 let mut output = BufWriter::new(output.lock());
-                log!(f output, "{GREEN}[DEBUG] The REPL has started.{RESET}\n");
+                log!(info_f output, "The REPL has started.\n");
                 output
                     .write_all(instance.start_message().as_bytes())
                     .unwrap();
@@ -354,7 +353,7 @@ pub trait Runnable: Sized {
                     let line = chomp(&instance.input().read());
                     if &line[..] == ":quit" || &line[..] == ":exit" {
                         instance.finish();
-                        log!(f output, "{GREEN}[DEBUG] The REPL has finished successfully.{RESET}\n");
+                        log!(info_f output, "The REPL has finished successfully.\n");
                         process::exit(0);
                     }
                     lines.push_str(&line);
@@ -376,7 +375,7 @@ pub trait Runnable: Sized {
                                 .unwrap_or(false)
                             {
                                 instance.finish();
-                                log!(f output, "{GREEN}[DEBUG] The REPL has finished successfully.{RESET}\n");
+                                log!(info_f output, "The REPL has finished successfully.\n");
                                 process::exit(0);
                             }
                             errs.fmt_all_stderr();

--- a/compiler/erg_compiler/codegen.rs
+++ b/compiler/erg_compiler/codegen.rs
@@ -5,7 +5,6 @@ use std::fmt;
 use std::process;
 
 use erg_common::cache::CacheSet;
-use erg_common::color::{GREEN, RESET};
 use erg_common::config::{ErgConfig, Input};
 use erg_common::error::{Location, MultiErrorDisplay};
 use erg_common::opcode::Opcode;
@@ -378,13 +377,13 @@ impl CodeGenerator {
     fn write_instr(&mut self, code: Opcode) {
         self.mut_cur_block_codeobj().code.push(code as u8);
         self.mut_cur_block().lasti += 1;
-        // log!("wrote: {}", code);
+        // log!(info "wrote: {}", code);
     }
 
     fn write_arg(&mut self, code: u8) {
         self.mut_cur_block_codeobj().code.push(code);
         self.mut_cur_block().lasti += 1;
-        // log!("wrote: {}", code);
+        // log!(info "wrote: {}", code);
     }
 
     fn stack_inc(&mut self) {
@@ -1414,7 +1413,7 @@ impl CodeGenerator {
     }
 
     pub fn codegen(&mut self, hir: HIR) -> CodeObj {
-        log!("{GREEN}[DEBUG] the code-generating process has started.{RESET}");
+        log!(info "the code-generating process has started.{RESET}");
         self.unit_size += 1;
         self.units.push(CodeGenUnit::new(
             self.unit_size,
@@ -1482,7 +1481,7 @@ impl CodeGenerator {
                 self.mut_cur_block().prev_lineno += ld;
             }
         }
-        log!("{GREEN}[DEBUG] the code-generating process has completed.{RESET}");
+        log!(info "the code-generating process has completed.{RESET}");
         unit.codeobj
     }
 }

--- a/compiler/erg_compiler/compile.rs
+++ b/compiler/erg_compiler/compile.rs
@@ -3,7 +3,6 @@
 //! コンパイラーを定義する
 use std::path::Path;
 
-use erg_common::color::{GREEN, RESET};
 use erg_common::config::{ErgConfig, Input};
 use erg_common::error::MultiErrorDisplay;
 use erg_common::log;
@@ -159,7 +158,7 @@ impl Compiler {
     }
 
     pub fn compile(&mut self, src: Str, mode: &str) -> Result<CodeObj, CompileErrors> {
-        log!("{GREEN}[DEBUG] the compiling process has started.{RESET}");
+        log!(info "the compiling process has started");
         let mut cfg = self.cfg.copy();
         cfg.input = Input::Str(src);
         let mut parser = ParserRunner::new(cfg);
@@ -181,9 +180,10 @@ impl Compiler {
             .check(hir)
             .map_err(|errs| self.convert(errs))?;
         let codeobj = self.code_generator.codegen(hir);
-        log!("{GREEN}code object:\n{}", codeobj.code_info());
+        log!(info "code object:\n{}", codeobj.code_info());
         log!(
-            "[DEBUG] the compiling process has completed, found errors: {}{RESET}",
+            c GREEN,
+            "the compiling process has completed, found errors: {}",
             self.code_generator.errs.len()
         );
         if self.code_generator.errs.is_empty() {

--- a/compiler/erg_compiler/context/compare.rs
+++ b/compiler/erg_compiler/context/compare.rs
@@ -40,7 +40,7 @@ impl Context {
         if sub.is_cachable() && sup.is_cachable() {
             let res = GLOBAL_TYPE_CACHE.get(&SubtypePair::new(sub.clone(), sup.clone()));
             if res.is_some() {
-                log!("cache hit");
+                log!(info "cache hit");
             }
             res
         } else {
@@ -242,7 +242,7 @@ impl Context {
     /// make judgments that include supertypes in the same namespace & take into account glue patches
     /// 同一名前空間にある上位型を含めた判定&接着パッチを考慮した判定を行う
     fn nominal_supertype_of(&self, lhs: &Type, rhs: &Type) -> bool {
-        log!("nominal_supertype_of:\nlhs: {lhs}\nrhs: {rhs}");
+        log!(info "nominal_supertype_of:\nlhs: {lhs}\nrhs: {rhs}");
         if let Some(res) = self.inquire_cache(rhs, lhs) {
             return res;
         }
@@ -345,12 +345,12 @@ impl Context {
     /// assert!(sup_conforms(?E(<: Eq(?R)), {Nat, Eq(T)}))
     fn _sub_conforms(&self, free: &FreeTyVar, inst_pair: &TraitInstance) -> bool {
         let (_sub, sup) = free.crack_bound_types().unwrap();
-        log!("{free}");
+        log!(info "{free}");
         free.forced_undoable_link(&inst_pair.sub_type);
-        log!("{free}");
+        log!(info "{free}");
         let judge = self.subtype_of(&sup, &inst_pair.sup_trait);
         free.undo();
-        log!("{free}");
+        log!(info "{free}");
         judge
     }
 
@@ -364,7 +364,7 @@ impl Context {
     /// 単一化、評価等はここでは行わない、スーパータイプになる可能性があるかだけ判定する
     /// ので、lhsが(未連携)型変数の場合は単一化せずにtrueを返す
     pub(crate) fn structural_supertype_of(&self, lhs: &Type, rhs: &Type) -> bool {
-        log!("structural_supertype_of:\nlhs: {lhs}\nrhs: {rhs}");
+        log!(info "structural_supertype_of:\nlhs: {lhs}\nrhs: {rhs}");
         match (lhs, rhs) {
             (Subr(ls), Subr(rs)) if ls.kind.same_kind_as(&rs.kind) => {
                 if ls.kind.self_t().is_some() {
@@ -632,7 +632,7 @@ impl Context {
                     self.subtype_of(l, r)
                 }
                 (TyParam::Type(l), TyParam::Type(r), Variance::Covariant) => {
-                    // if matches!(r.as_ref(), &Type::Refinement(_)) { log!("{l}, {r}, {}", self.structural_supertype_of(l, r, bounds, Some(lhs_variance))); }
+                    // if matches!(r.as_ref(), &Type::Refinement(_)) { log!(info "{l}, {r}, {}", self.structural_supertype_of(l, r, bounds, Some(lhs_variance))); }
                     self.supertype_of(l, r)
                 }
                 // Invariant
@@ -788,7 +788,7 @@ impl Context {
                 lhs.preds.clone().concat(rhs_preds),
             )
         } else {
-            log!("{lhs}\n{rhs}");
+            log!(info "{lhs}\n{rhs}");
             todo!()
         }
     }

--- a/compiler/erg_compiler/context/inquire.rs
+++ b/compiler/erg_compiler/context/inquire.rs
@@ -1,7 +1,6 @@
 // (type) getters & validators
 use std::option::Option; // conflicting to Type::Option
 
-use erg_common::color::{GREEN, RED};
 use erg_common::dict::Dict;
 use erg_common::error::ErrorCore;
 use erg_common::levenshtein::levenshtein;
@@ -365,7 +364,7 @@ impl Context {
             ..
         }) = t
         {
-            log!("{}, {}", callee.ref_t(), after);
+            log!(info "{}, {}", callee.ref_t(), after);
             self.reunify(callee.ref_t(), after, Some(callee.loc()), None)?;
         }
         Ok(())
@@ -531,8 +530,8 @@ impl Context {
                         param_ty.name.as_ref(),
                     )
                     .map_err(|e| {
-                        log!("{RED}semi-unification failed with {callee}\n{arg_t} !<: {param_t}");
-                        log!("errno: {}{GREEN}", e.core.errno);
+                        log!(err "semi-unification failed with {callee}\n{arg_t} !<: {param_t}");
+                        log!(err "errno: {}", e.core.errno);
                         // REVIEW:
                         let name = callee.var_full_name().unwrap_or_else(|| "".to_string());
                         let name = name
@@ -625,13 +624,13 @@ impl Context {
             fmt_slice(kw_args)
         );
         self.substitute_call(obj, method_name, &instance, pos_args, kw_args)?;
-        log!("Substituted:\ninstance: {instance}");
+        log!(info "Substituted:\ninstance: {instance}");
         let res = self.eval.eval_t_params(instance, &self, self.level)?;
-        log!("Params evaluated:\nres: {res}\n");
+        log!(info "Params evaluated:\nres: {res}\n");
         self.propagate(&res, obj)?;
-        log!("Propagated:\nres: {res}\n");
+        log!(info "Propagated:\nres: {res}\n");
         let res = self.resolve_trait(res)?;
-        log!("Trait resolved:\nres: {res}\n");
+        log!(info "Trait resolved:\nres: {res}\n");
         Ok(res)
     }
 

--- a/compiler/erg_compiler/context/mod.rs
+++ b/compiler/erg_compiler/context/mod.rs
@@ -524,7 +524,7 @@ impl Context {
         } else {
             format!("{parent}::{name}", parent = self.name)
         };
-        log!("{}: current namespace: {name}", fn_name!());
+        log!(info "{}: current namespace: {name}", fn_name!());
         self.outer = Some(Box::new(mem::take(self)));
         self.name = name.into();
         self.kind = kind;
@@ -544,7 +544,7 @@ impl Context {
         }
         if let Some(parent) = &mut self.outer {
             *self = mem::take(parent);
-            log!("{}: current namespace: {}", fn_name!(), self.name);
+            log!(info "{}: current namespace: {}", fn_name!(), self.name);
             if !uninited_errs.is_empty() {
                 Err(uninited_errs)
             } else {

--- a/compiler/erg_compiler/context/register.rs
+++ b/compiler/erg_compiler/context/register.rs
@@ -303,7 +303,7 @@ impl Context {
             }
             // TODO: visibility
             let vi = VarInfo::new(found_t, muty, Private, VarKind::Defined(id));
-            log!("Registered {}::{name}: {}", self.name, &vi.t);
+            log!(info "Registered {}::{name}: {}", self.name, &vi.t);
             self.params.push((Some(name.clone()), vi));
             Ok(())
         }

--- a/compiler/erg_compiler/context/tyvar.rs
+++ b/compiler/erg_compiler/context/tyvar.rs
@@ -975,7 +975,7 @@ impl Context {
         sup_loc: Option<Location>,
         param_name: Option<&Str>,
     ) -> TyCheckResult<()> {
-        erg_common::log!("trying sub_unify:\nmaybe_sub: {maybe_sub}\nmaybe_sup: {maybe_sup}");
+        erg_common::log!(info "trying sub_unify:\nmaybe_sub: {maybe_sub}\nmaybe_sup: {maybe_sup}");
         // In this case, there is no new information to be gained
         // この場合、特に新しく得られる情報はない
         if maybe_sub == &Type::Never || maybe_sup == &Type::Obj {

--- a/compiler/erg_compiler/effectcheck.rs
+++ b/compiler/erg_compiler/effectcheck.rs
@@ -2,7 +2,6 @@
 //! SideEffectCheckerを実装
 //! 関数や不変型に副作用がないかチェックする
 
-use erg_common::color::{GREEN, RESET};
 use erg_common::log;
 use erg_common::traits::Stream;
 use erg_common::vis::Visibility;
@@ -78,7 +77,7 @@ impl SideEffectChecker {
     pub fn check(mut self, hir: HIR) -> EffectResult<HIR> {
         self.path_stack.push((hir.name.clone(), Private));
         self.block_stack.push(Module);
-        log!("{GREEN}[DEBUG] the side-effects checking process has started.{RESET}");
+        log!(info "the side-effects checking process has started.{RESET}");
         // トップレベルでは副作用があっても問題なく、純粋性違反がないかのみチェックする
         for expr in hir.module.iter() {
             match expr {
@@ -104,7 +103,7 @@ impl SideEffectChecker {
                 other => todo!("{other}"),
             }
         }
-        log!("{GREEN}[DEBUG] the side-effects checking process has completed, found errors: {}{RESET}", self.errs.len());
+        log!(info "the side-effects checking process has completed, found errors: {}{RESET}", self.errs.len());
         if self.errs.is_empty() {
             Ok(hir)
         } else {

--- a/compiler/erg_compiler/ownercheck.rs
+++ b/compiler/erg_compiler/ownercheck.rs
@@ -1,4 +1,3 @@
-use erg_common::color::{GREEN, RESET};
 use erg_common::dict::Dict;
 use erg_common::error::Location;
 use erg_common::log;
@@ -57,7 +56,7 @@ impl OwnershipChecker {
     // moveされた後の変数が使用されていないかチェックする
     // ProceduralでないメソッドでRefMutが使われているかはSideEffectCheckerでチェックする
     pub fn check(mut self, hir: HIR) -> OwnershipResult<HIR> {
-        log!("{GREEN}[DEBUG] the ownership checking process has started.{RESET}");
+        log!(info "the ownership checking process has started.{RESET}");
         self.path_stack.push((hir.name.clone(), Private));
         self.dict
             .insert(Str::from(self.full_path()), LocalVars::default());
@@ -84,7 +83,7 @@ impl OwnershipChecker {
     fn check_expr(&mut self, expr: &Expr, ownership: Ownership) {
         match expr {
             Expr::Def(def) => {
-                log!("define: {}", def.sig);
+                log!(info "define: {}", def.sig);
                 self.define(def);
                 let name = match &def.sig {
                     Signature::Var(var) => var.inspect().clone(),

--- a/compiler/erg_parser/parse.rs
+++ b/compiler/erg_parser/parse.rs
@@ -5,7 +5,6 @@
 use std::fmt::Debug;
 use std::mem;
 
-use erg_common::color::{GREEN, RED, RESET};
 use erg_common::config::ErgConfig;
 use erg_common::config::Input;
 use erg_common::error::Location;
@@ -31,7 +30,8 @@ macro_rules! debug_call_info {
     ($self: ident) => {
         $self.level += 1;
         log!(
-            "[DEBUG]\n{} ({}) entered {}, cur: {}",
+            c GREEN,
+            "\n{} ({}) entered {}, cur: {}",
             " ".repeat($self.level),
             $self.level,
             fn_name!(),
@@ -286,7 +286,7 @@ impl Parser {
 
     fn skip_and_throw_syntax_err(&mut self, caused_by: &str) -> ParseError {
         let loc = self.peek().unwrap().loc();
-        log!("{RED}[DEBUG] error caused by: {caused_by}{GREEN}");
+        log!(err "error caused by: {caused_by}");
         self.next_expr();
         ParseError::simple_syntax_error(0, loc)
     }
@@ -366,8 +366,8 @@ impl Parser {
         if self.tokens.is_empty() {
             return Ok(AST::new(mod_name, Module::empty()));
         }
-        log!("{GREEN}[DEBUG] the parsing process has started.");
-        log!("token stream: {}", self.tokens);
+        log!(info "the parsing process has started.");
+        log!(info "token stream: {}", self.tokens);
         let module = match self.try_reduce_module() {
             Ok(module) => module,
             Err(_) => {
@@ -380,13 +380,13 @@ impl Parser {
                 .push(ParseError::compiler_bug(0, loc, fn_name!(), line!()));
             return Err(mem::take(&mut self.errs));
         }
-        log!("[DEBUG] the parsing process has completed.");
-        log!("AST:\n{module}");
-        log!("[DEBUG] the desugaring process has started.");
+        log!(info "the parsing process has completed.");
+        log!(info "AST:\n{module}");
+        log!(info "the desugaring process has started.");
         let mut desugarer = Desugarer::new();
         let module = desugarer.desugar(module);
-        log!("AST (desugared):\n{module}");
-        log!("[DEBUG] the desugaring process has completed.{RESET}");
+        log!(info "AST (desugared):\n{module}");
+        log!(info "the desugaring process has completed.{RESET}");
         if self.errs.is_empty() {
             Ok(AST::new(mod_name, module))
         } else {
@@ -976,7 +976,7 @@ impl Parser {
                 }
             }
             Some(t) if t.category_is(TC::BinOp) || t.category_is(TC::UnaryOp) => {
-                log!("[DEBUG] error caused by: {}", fn_name!());
+                log!(info "error caused by: {}", fn_name!());
                 let err = ParseError::syntax_error(
                     line!() as usize,
                     t.loc(),


### PR DESCRIPTION
While `debug` feature is helpful for debugging, there left some boring jobs like:
```Rust
use erg_common::color::*;
log!("{GREEN}[DEBUG] msg {RESET}");
```

Currently, debug outputs look like:
<img width="556" alt="スクリーンショット 2022-08-30 11 09 12" src="https://user-images.githubusercontent.com/54735373/187332830-17baa51b-ba97-499f-964d-5a1ef5f37012.png">
Once we forget to end with `"msg {RESET}"`, output are painted in all green and it is a little bit difficult to see.
Also, handwritten `[DEBUG]` is not aligned due to different length of file/line info.

Thus, I introduced these fix in `log!` macro
Changes proposed in this PR:
- Inserting `[DEBUG]` in front of file/line information to log in default.
- Forcing color reset for every `log!`
- Adding directives in `log!` to switch colors we like.
- Shorthand for green output(`info`) and red output(`err`)(for debugging, maybe warn is not necessary)
(- documentation for `log!` directives above)

With these utilities, we can easily write neat logs with:
```Rust
log!(info "compiler reached {}", fn_name!());
log!(err "error occured in {}!", fn_name!());
```
and outputs look like:
<img width="552" alt="スクリーンショット 2022-08-30 11 08 20" src="https://user-images.githubusercontent.com/54735373/187332896-ca99e9c2-a7be-4199-ace1-3988f9e727dc.png">

@mtshiba
