### PR TITLE
Fix to trim unnecessary newline

### DIFF
--- a/compiler/erg_common/config.rs
+++ b/compiler/erg_common/config.rs
@@ -107,7 +107,7 @@ impl Input {
         match self {
             Self::File(_filename) => todo!(),
             Self::Pipe(s) | Self::Str(s) => s.clone(),
-            Self::REPL => GLOBAL_STDIN.reread(),
+            Self::REPL => Str::from(GLOBAL_STDIN.reread().trim_end().to_owned()),
             Self::Dummy => panic!("cannot read from a dummy file"),
         }
     }


### PR DESCRIPTION
Fixes #63.

In the file input, code is split at newlines, but in the REPL evaluates each line, so newline is included.
The extra newlines and whitespaces at the end of the line are trimmed.

Changes proposed in this PR:
In REPL

```erg
1│ a = 2

   ^
```
to
```erg
1│ a = 2
   ^
```

@mtshiba