### PR TITLE
Implimented the exec() method in Runner

### DIFF
--- a/compiler/erg_parser/lex.rs
+++ b/compiler/erg_parser/lex.rs
@@ -39,7 +39,12 @@ impl Runnable for LexerRunner {
     fn clear(&mut self) {}
 
     fn exec(&mut self) -> Result<(), Self::Errs> {
-        todo!()
+        let lexer = Lexer::from_str(self.input().read());
+        let ts = lexer
+            .lex()
+            .map_err(|errs| LexerRunnerErrors::convert(self.input(), errs))?;
+        println!("{ts}");
+        Ok(())
     }
 
     fn eval(&mut self, src: Str) -> Result<String, LexerRunnerErrors> {

--- a/compiler/erg_parser/parse.rs
+++ b/compiler/erg_parser/parse.rs
@@ -189,7 +189,9 @@ impl Runnable for ParserRunner {
     fn clear(&mut self) {}
 
     fn exec(&mut self) -> Result<(), Self::Errs> {
-        todo!()
+        let ast = self.parse()?;
+        println!("{ast}");
+        Ok(())
     }
 
     fn eval(&mut self, src: Str) -> Result<String, ParserRunnerErrors> {


### PR DESCRIPTION
Fixes #29 .

Implemented unimplemented exec() methods of LexerRunner and ParseRunner.

This will allow the following commands to be executed.

```sh
erg --mode lex file_name
erg --mode parse file_name
```

Since I honestly don't know what kind of output I should get, I have set the output to be the same as debugging.

I could be wrong, so I made a draft.

Changes proposed in this PR:
- Implement exec() of LexerRunner
- Implement exec() of ParseRunner

@mtshiba
