### PR TITLE
Fix #115, #133

### DIFF
--- a/compiler/erg_compiler/main.rs
+++ b/compiler/erg_compiler/main.rs
@@ -3,6 +3,7 @@ extern crate erg_compiler;
 extern crate erg_parser;
 
 use std::process;
+use std::thread;
 
 use erg_common::config::ErgConfig;
 use erg_common::traits::Runnable;
@@ -14,7 +15,7 @@ use erg_parser::ParserRunner;
 
 use erg_type::deserialize::Deserializer;
 
-fn main() {
+fn run() {
     let cfg = ErgConfig::parse();
     match cfg.mode {
         "lex" => {
@@ -33,5 +34,21 @@ fn main() {
             println!("invalid mode: {other}");
             process::exit(1);
         }
+    }
+}
+
+fn main() {
+    if cfg!(windows) {
+        const STACK_SIZE: usize = 4 * 1024 * 1024;
+
+        let child = thread::Builder::new()
+            .stack_size(STACK_SIZE)
+            .spawn(run)
+            .unwrap();
+
+        // Wait for thread to join
+        child.join().unwrap();
+    } else {
+        run();
     }
 }

--- a/compiler/erg_parser/main.rs
+++ b/compiler/erg_parser/main.rs
@@ -2,6 +2,7 @@ extern crate erg_common;
 extern crate erg_parser;
 
 use std::process;
+use std::thread;
 
 use erg_common::config::ErgConfig;
 use erg_common::traits::Runnable;
@@ -9,7 +10,7 @@ use erg_common::traits::Runnable;
 use erg_parser::lex::LexerRunner;
 use erg_parser::ParserRunner;
 
-fn main() {
+fn run() {
     let cfg = ErgConfig::parse();
     match cfg.mode {
         "lex" => {
@@ -22,5 +23,21 @@ fn main() {
             println!("invalid mode: {other}");
             process::exit(1);
         }
+    }
+}
+
+fn main() {
+    if cfg!(windows) {
+        const STACK_SIZE: usize = 4 * 1024 * 1024;
+
+        let child = thread::Builder::new()
+            .stack_size(STACK_SIZE)
+            .spawn(run)
+            .unwrap();
+
+        // Wait for thread to join
+        child.join().unwrap();
+    } else {
+        run();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ extern crate erg_compiler;
 extern crate erg_parser;
 
 use std::process;
+use std::thread;
 
 use erg_common::config::ErgConfig;
 use erg_common::traits::Runnable;
@@ -16,7 +17,7 @@ use erg_type::deserialize::Deserializer;
 
 use erg::dummy::DummyVM;
 
-fn main() {
+fn run() {
     let cfg = ErgConfig::parse();
     match cfg.mode {
         "lex" => {
@@ -38,5 +39,21 @@ fn main() {
             eprintln!("invalid mode: {other}");
             process::exit(1);
         }
+    }
+}
+
+fn main() {
+    if cfg!(windows) {
+        const STACK_SIZE: usize = 4 * 1024 * 1024;
+
+        let child = thread::Builder::new()
+            .stack_size(STACK_SIZE)
+            .spawn(run)
+            .unwrap();
+
+        // Wait for thread to join
+        child.join().unwrap();
+    } else {
+        run();
     }
 }


### PR DESCRIPTION
Fixes #115, #133.

Using the fact that a sub-process can set the stack size., I have made the compiler run the main process in a sub-process on Windows.

Improving the efficiency of the parser will be a future issue.
