### PR TITLE
Repel invalid blocks with equals and whitespace in REPL

### DIFF
--- a/compiler/erg_common/traits.rs
+++ b/compiler/erg_common/traits.rs
@@ -312,6 +312,12 @@ fn expect_block(src: &str) -> bool {
     src.ends_with(&['.', '=', ':']) || src.ends_with("->") || src.ends_with("=>")
 }
 
+// In the REPL, it is invalid for these symbols to be at the beginning of a line
+fn expect_invalid_block(src: &str) -> bool {
+    let src = src.trim_end();
+    src.starts_with(&['.', '=', ':']) || src.starts_with("->") || src.starts_with("=>")
+}
+
 /// This trait implements REPL (Read-Eval-Print-Loop) automatically
 /// The `exec` method is called for file input, etc.
 pub trait Runnable: Sized {
@@ -381,7 +387,9 @@ pub trait Runnable: Sized {
                         &line[..]
                     };
                     lines.push_str(line);
-                    if expect_block(line) || line.starts_with(' ') {
+                    if expect_block(line) && !expect_invalid_block(line)
+                        || line.starts_with(' ') && lines.contains('\n')
+                    {
                         lines += "\n";
                         output.write_all(instance.ps2().as_bytes()).unwrap();
                         output.flush().unwrap();

--- a/compiler/erg_common/traits.rs
+++ b/compiler/erg_common/traits.rs
@@ -314,8 +314,8 @@ fn expect_block(src: &str) -> bool {
 
 // In the REPL, it is invalid for these symbols to be at the beginning of a line
 fn expect_invalid_block(src: &str) -> bool {
-    let src = src.trim_end();
-    src.starts_with(&['.', '=', ':']) || src.starts_with("->") || src.starts_with("=>")
+    let src = src.trim_start();
+    src.starts_with(&['.', '=', ':']) || src.starts_with("->")
 }
 
 /// This trait implements REPL (Read-Eval-Print-Loop) automatically


### PR DESCRIPTION
Fixes #58

I'm not using `Parse`, so there could be some problem or unintended behavior.

Currently, a block is expected when an equal, etc. is at the beginning of a line in REPL.

However, in the REPL, there should be no token that expects a block at the beginning of a line, so I repel this with an if statement.

For whitespace, I added the condition that "lines" is expected to be a block if it contains line breaks.

@mtshiba
