### PR TITLE
Added handling of escape char

### DIFF
--- a/compiler/erg_parser/lex.rs
+++ b/compiler/erg_parser/lex.rs
@@ -555,20 +555,13 @@ impl Lexer /*<'a>*/ {
                 return Ok(token);
             } else {
                 let c = self.consume().unwrap();
+                            if Self::is_bidi(next_c) {
+                                return Err(self._invalid_unicode_character(&s));
+                            }
                 s.push(c);
                 if Self::is_bidi(c) {
-                    let token = self.emit_token(Illegal, &s);
-                    return Err(LexError::syntax_error(
-                        0,
-                        token.loc(),
-                        switch_lang!(
-                            "japanese" => "不正なユニコード文字(双方向オーバーライド)が文字列中に使用されています",
-                            "simplified_chinese" => "注释中使用了非法的unicode字符（双向覆盖）",
-                            "traditional_chinese" => "註釋中使用了非法的unicode字符（雙向覆蓋）",
-                            "english" => "invalid unicode character (bi-directional override) in string literal",
-                        ),
-                        None,
-                    ));
+                        return Err(self._invalid_unicode_character(&s));
+                    }
                 }
             }
         }
@@ -584,6 +577,22 @@ impl Lexer /*<'a>*/ {
             ),
             None,
         ))
+    }
+
+    // for single strings and multi strings
+    fn _invalid_unicode_character(&mut self, s: &str) -> LexError {
+        let token = self.emit_token(Illegal, s);
+        LexError::syntax_error(
+            0,
+            token.loc(),
+            switch_lang!(
+                "japanese" => "不正なユニコード文字(双方向オーバーライド)が文字列中に使用されています",
+                "simplified_chinese" => "注释中使用了非法的unicode字符（双向覆盖）",
+                "traditional_chinese" => "註釋中使用了非法的unicode字符（雙向覆蓋）",
+                "english" => "invalid unicode character (bi-directional override) in string literal",
+            ),
+            None,
+        )
     }
 }
 

--- a/src/scripts/repl_server.py
+++ b/src/scripts/repl_server.py
@@ -32,7 +32,7 @@ while True:
         except e:
             __res = str(e)
         __already_loaded = True
-        __out = __sys.stdout.getvalue().strip()
+        __out = __sys.stdout.getvalue()[:-1]
         __res = __out + '\n' + __res
         __client_socket.send(__res.encode())
     else:


### PR DESCRIPTION
Fixes #157.

Changes proposed in this PR:
- It is extracted as a method with a bidirectional override error.
It can also be used to handle error for multiple strings in the future.

- Escape characters are now handled
If the current character is an escape character, skip it and look at the next character.
If the next character is a control character, insert it into the String as a control character.
There are only three control characters added this time (single quotation marks may not be necessary).
This is because I do not know how the other control characters are handled at compile time.

```sh
cargo run -- --mode lex
```

```sh
>>> "\"\"\"\"\""
[StrLit """"""", EOF ]
>>> "\\\\\\\\"
[StrLit "\\\\", EOF ]
>>> "\n\n\n\n"
[StrLit "\n\n\n\n", EOF ]
>>> "a\t\ta" 
[StrLit "a        a", EOF ]
```

@mtshiba
