### PR TITLE
Added error on line braek in string

### DIFF
--- a/compiler/erg_parser/tests/failed_str_lit.er
+++ b/compiler/erg_parser/tests/failed_str_lit.er
@@ -1,0 +1,4 @@
+# compile error
+a = "
+    hello, world
+"

--- a/compiler/erg_parser/tests/parse_test.rs
+++ b/compiler/erg_parser/tests/parse_test.rs
@@ -7,6 +7,11 @@ use erg_parser::lex::Lexer;
 use erg_parser::ParserRunner;
 
 #[test]
+fn parse_str_literal() -> Result<(), ParserRunnerErrors> {
+    expect_failure("tests/failed_str_lit.er")
+}
+
+#[test]
 fn parse_dependent() -> Result<(), ParserRunnerErrors> {
     expect_success("tests/dependent.er")
 }


### PR DESCRIPTION
Related: #167.

It turns out that the current string also works as a multi-line string.

However, this is invalid and has been fixed.

Existing tokenize tests have passed successfully.

Changes proposed in this PR:
- "match" statement is used instead of "if" statement.
- Now returns an error if '\n' is input
- Added error and hint text
- Added test to check for parse error

@mtshiba
