### PR TITLE
Implemtent the multi-line string method

### DIFF
--- a/compiler/erg_common/traits.rs
+++ b/compiler/erg_common/traits.rs
@@ -311,7 +311,9 @@ fn expect_block(src: &str) -> bool {
     src.ends_with(&['.', '=', ':'])
         || src.ends_with("->")
         || src.ends_with("=>")
-        || src.contains("\"\"\"")
+        // when `"""` are on the same line
+        // e.g. """something"""
+        || src.contains("\"\"\"") && src.find("\"\"\"") == src.rfind("\"\"\"")
 }
 
 // In the REPL, it is invalid for these symbols to be at the beginning of a line
@@ -411,8 +413,6 @@ pub trait Runnable: Sized {
                     };
                     lines.push_str(line);
 
-                    // ブロック内ならブロック内の関数を使ってcontinueするかしないかを判断
-                    // ブロック外ならexpect_blockかどうかを判断j
                     if in_block {
                         if is_in_the_expected_block(line, &lines, &mut in_block) {
                             lines += "\n";

--- a/compiler/erg_common/traits.rs
+++ b/compiler/erg_common/traits.rs
@@ -308,13 +308,30 @@ pub trait LimitedDisplay {
 // for Runnable::run
 fn expect_block(src: &str) -> bool {
     let src = src.trim_end();
-    src.ends_with(&['.', '=', ':']) || src.ends_with("->") || src.ends_with("=>")
+    src.ends_with(&['.', '=', ':'])
+        || src.ends_with("->")
+        || src.ends_with("=>")
+        || src.contains("\"\"\"")
 }
 
 // In the REPL, it is invalid for these symbols to be at the beginning of a line
 fn expect_invalid_block(src: &str) -> bool {
     let src = src.trim_start();
-    src.starts_with(&['.', '=', ':']) || src.starts_with("->")
+    src.starts_with(&['.', '=', ':']) || src.starts_with("->") || src.starts_with("=>")
+}
+
+fn is_in_the_expected_block(src: &str, lines: &str, in_block: &mut bool) -> bool {
+    if lines.contains("\"\"\"") {
+        if src.ends_with("\"\"\"") {
+            *in_block = false;
+            false
+        } else {
+            true
+        }
+    } else {
+        *in_block = false;
+        !expect_invalid_block(src) || src.starts_with(' ') && lines.contains('\n')
+    }
 }
 
 /// This trait implements REPL (Read-Eval-Print-Loop) automatically
@@ -367,6 +384,7 @@ pub trait Runnable: Sized {
                 }
                 output.write_all(instance.ps1().as_bytes()).unwrap();
                 output.flush().unwrap();
+                let mut in_block = false;
                 let mut lines = String::new();
                 loop {
                     let line = chomp(&instance.input().read());
@@ -392,14 +410,33 @@ pub trait Runnable: Sized {
                         &line[..]
                     };
                     lines.push_str(line);
-                    if expect_block(line) && !expect_invalid_block(line)
-                        || line.starts_with(' ') && lines.contains('\n')
-                    {
+
+                    // ブロック内ならブロック内の関数を使ってcontinueするかしないかを判断
+                    // ブロック外ならexpect_blockかどうかを判断j
+                    if in_block {
+                        if is_in_the_expected_block(line, &lines, &mut in_block) {
+                            lines += "\n";
+                            output.write_all(instance.ps2().as_bytes()).unwrap();
+                            output.flush().unwrap();
+                            continue;
+                        }
+                    } else if expect_block(line) {
+                        in_block = true;
                         lines += "\n";
                         output.write_all(instance.ps2().as_bytes()).unwrap();
                         output.flush().unwrap();
                         continue;
                     }
+
+                    // if (expect_block(line) && !in_block)
+                    //     || (is_in_the_expected_block(line, &lines, &mut in_block) && in_block)
+                    // {
+                    //     lines += "\n";
+                    //     output.write_all(instance.ps2().as_bytes()).unwrap();
+                    //     output.flush().unwrap();
+                    //     continue;
+                    // }
+
                     match instance.eval(mem::take(&mut lines)) {
                         Ok(out) => {
                             output.write_all((out + "\n").as_bytes()).unwrap();

--- a/compiler/erg_parser/lex.rs
+++ b/compiler/erg_parser/lex.rs
@@ -688,6 +688,96 @@ impl Lexer /*<'a>*/ {
         ))
     }
 
+    fn lex_multi_line_str(&mut self) -> LexResult<Token> {
+        let mut s = "\"\"\"".to_string();
+        while let Some(c) = self.peek_cur_ch() {
+            match c {
+                '"' => {
+                    s.push(self.consume().unwrap());
+                    let next_c = self.peek_cur_ch();
+                    let aft_next_c = self.peek_next_ch();
+                    if next_c.is_none() || aft_next_c.is_none() {
+                        let token = self.emit_token(Illegal, &s);
+                        return Err(LexError::syntax_error(
+                            0,
+                            token.loc(),
+                            switch_lang!(
+                                "japanese" => "文字列が\"\"\"によって閉じられていません",
+                                "simplified_chinese" => "字符串没有被\"\"\"关闭",
+                                "traditional_chinese" => "字符串没有被\"\"\"关闭",
+                                "english" => "the string is not closed by \"\"\"",
+                            ),
+                            None,
+                        ));
+                    }
+                    let next_c = self.consume().unwrap();
+                    let aft_next_c = self.consume().unwrap();
+                    if next_c == '"' && aft_next_c == '"' {
+                        let token = self.emit_token(StrLit, &s);
+                        return Ok(token);
+                    }
+                }
+                _ => {
+                    let c = self.consume().unwrap();
+                    if c == '\\' {
+                        let next_c = self.consume().unwrap();
+                        match next_c {
+                            '0' => s.push('\0'),
+                            'r' => s.push('\r'),
+                            '\'' => {
+                                s.push('\'');
+                                if self.peek_next_ch().is_some()
+                                    && self.peek_next_ch().unwrap() == '\n'
+                                {
+                                    continue; // Escaping a line break if only '\' comes at the end
+                                }
+                            }
+                            '"' => s.push('"'),
+                            't' => s.push_str("    "), // tab is invalid, so changed into 4 whitespace
+                            '\\' => s.push('\\'),
+                            'n' => s.push('\n'),
+                            '\n' => {
+                                self.lineno_token_starts += 1;
+                                self.col_token_starts = 0;
+                            }
+                            _ => {
+                                let token = self.emit_token(Illegal, &format!("\\{next_c}"));
+                                return Err(LexError::syntax_error(
+                                    0,
+                                    token.loc(),
+                                    switch_lang!(
+                                        "japanese" => format!("不正なエスケープシーケンスです: \\{}", next_c),
+                                        "simplified_chinese" => format!("不合法的转义序列: \\{}", next_c),
+                                        "traditional_chinese" => format!("不合法的轉義序列: \\{}", next_c),
+                                        "english" => format!("illegal escape sequence: \\{}", next_c),
+                                    ),
+                                    None,
+                                ));
+                            }
+                        }
+                    } else {
+                        s.push(c);
+                        if Self::is_bidi(c) {
+                            return Err(self._invalid_unicode_character(&s));
+                        }
+                    }
+                }
+            }
+        }
+        let token = self.emit_token(Illegal, &s);
+        Err(LexError::syntax_error(
+            0,
+            token.loc(),
+            switch_lang!(
+                "japanese" => "文字列が\"\"\"によって閉じられていません",
+                "simplified_chinese" => "字符串没有被\"\"\"关闭",
+                "traditional_chinese" => "字符串没有被\"\"\"关闭",
+                "english" => "the string is not closed by \"\"\"",
+            ),
+            None,
+        ))
+    }
+
     // for single strings and multi strings
     fn _invalid_unicode_character(&mut self, s: &str) -> LexError {
         let token = self.emit_token(Illegal, s);

--- a/compiler/erg_parser/tests/multi_line_str_literal.er
+++ b/compiler/erg_parser/tests/multi_line_str_literal.er
@@ -27,3 +27,14 @@ complex_string = """\\\
 \r\n\
 \\"""
 print! complex_string
+
+quotation_mark = """\"\"\""""
+print! quotation_mark
+
+quotation_marks = """"
+""
+""\"
+\"\"\"""
+\"\""
+\"\"\""""
+print! quotation_marks

--- a/compiler/erg_parser/tests/multi_line_str_literal.er
+++ b/compiler/erg_parser/tests/multi_line_str_literal.er
@@ -3,7 +3,7 @@
     Str Literal
 ]#
 
-single_a = "line break\naaa\nbbbb\nccc\nline break"
+single_a = "line break\naaa\nbbb\nccc\nline break"
 print! single_a
 
 multi_line_a = """line break
@@ -13,12 +13,12 @@ ccc
 line break"""
 print! multi_line_a
 
-single_b = "ignore line break    hello,\n    worldignored line break"
+single_b = "ignore line break    Hello,\n    Worldignored line break"
 print! single_b
 
 multi_line_b = """ignore line break\
 \tHello,
-\tworld\
+\tWorld\
 ignored line break"""
 print! multi_line_b
 

--- a/compiler/erg_parser/tests/multi_line_str_literal.er
+++ b/compiler/erg_parser/tests/multi_line_str_literal.er
@@ -1,0 +1,29 @@
+#[
+    Multi-line Str Literal
+    Str Literal
+]#
+
+single_a = "line break\naaa\nbbbb\nccc\nline break"
+print! single_a
+
+multi_line_a = """line break
+aaa
+bbb
+ccc
+line break"""
+print! multi_line_a
+
+single_b = "ignore line break    hello,\n    worldignored line break"
+print! single_b
+
+multi_line_b = """ignore line break\
+\tHello,
+\tworld\
+ignored line break"""
+print! multi_line_b
+
+complex_string = """\\\
+\t\0\
+\r\n\
+\\"""
+print! complex_string

--- a/compiler/erg_parser/tests/tokenize_test.rs
+++ b/compiler/erg_parser/tests/tokenize_test.rs
@@ -12,12 +12,13 @@ use TokenKind::*;
 const FILE1: &str = "tests/test1_basic_syntax.er";
 const FILE2: &str = "tests/test2_advanced_syntax.er";
 const FILE3: &str = "tests/test3_literal_syntax.er";
+const FILE4: &str = "tests/multi_line_str_literal.er";
 
 #[test]
 fn test_lexer_for_basic() -> ParseResult<()> {
     let mut lexer = Lexer::new(Input::File(FILE1.into()));
     let newline = "\n";
-    let /*mut*/ token_array = vec![
+    let token_array = vec![
         (Newline, newline),
         (Newline, newline),
         (Symbol, "_a"),
@@ -120,9 +121,9 @@ fn test_lexer_for_basic() -> ParseResult<()> {
     ];
     let mut tok: Token;
     for (id, i) in token_array.into_iter().enumerate() {
+        print!("{id:>03}: ");
         tok = lexer.next().unwrap().unwrap();
         assert_eq!(tok, Token::from_str(i.0, i.1));
-        print!("{id:>03}: ");
         println!("{tok}");
     }
     Ok(())
@@ -132,7 +133,7 @@ fn test_lexer_for_basic() -> ParseResult<()> {
 fn test_lexer_for_advanced() -> ParseResult<()> {
     let mut lexer = Lexer::new(Input::File(FILE2.into()));
     let newline = "\n";
-    let /*mut*/ token_array = vec![
+    let token_array = vec![
         (Newline, newline),
         (Newline, newline),
         (Newline, newline),
@@ -212,7 +213,6 @@ fn test_lexer_for_advanced() -> ParseResult<()> {
         (Newline, newline),
         (EOF, ""),
     ];
-
     let mut tok: Token;
     for (id, i) in token_array.into_iter().enumerate() {
         print!("{id:>03}: ");
@@ -227,7 +227,7 @@ fn test_lexer_for_advanced() -> ParseResult<()> {
 fn test_lexer_for_literals() -> ParseResult<()> {
     let mut lexer = Lexer::new(Input::File(FILE3.into()));
     let newline = "\n";
-    let /*mut*/ token_array = vec![
+    let token_array = vec![
         (Newline, newline),
         (Newline, newline),
         (NatLit, "0"),
@@ -295,9 +295,80 @@ fn test_lexer_for_literals() -> ParseResult<()> {
         (Newline, newline),
         (Newline, newline),
         (Newline, newline),
-        // (EOF, ""),
+        (Newline, newline),
+        (EOF, ""),
     ];
+    let mut tok: Token;
+    for (id, i) in token_array.into_iter().enumerate() {
+        print!("{id:>03}: ");
+        tok = lexer.next().unwrap().unwrap();
+        assert_eq!(tok, Token::from_str(i.0, i.1));
+        println!("{tok}");
+    }
+    Ok(())
+}
 
+#[test]
+fn test_lexer_for_multi_line_str_literal() -> ParseResult<()> {
+    let mut lexer = Lexer::new(Input::File(FILE4.into()));
+    let newline = "\n";
+    let token_array = vec![
+        (Newline, newline),
+        (Newline, newline),
+        (Symbol, "single_a"),
+        (Equal, "="),
+        (StrLit, "\"line break\naaa\nbbb\nccc\nline break\""),
+        (Newline, newline),
+        (Symbol, "print!"),
+        (Symbol, "single_a"),
+        (Newline, newline),
+        (Newline, newline),
+        (Symbol, "multi_line_a"),
+        (Equal, "="),
+        (
+            StrLit,
+            "\"\"\"line break
+aaa
+bbb
+ccc
+line break\"\"\"",
+        ),
+        (Newline, newline),
+        (Symbol, "print!"),
+        (Symbol, "multi_line_a"),
+        (Newline, newline),
+        (Newline, newline),
+        (Symbol, "single_b"),
+        (Equal, "="),
+        (
+            StrLit,
+            "\"ignore line break    Hello,\n    Worldignored line break\"",
+        ),
+        (Newline, newline),
+        (Symbol, "print!"),
+        (Symbol, "single_b"),
+        (Newline, newline),
+        (Newline, newline),
+        (Symbol, "multi_line_b"),
+        (Equal, "="),
+        (
+            StrLit,
+            "\"\"\"ignore line break    Hello,
+    Worldignored line break\"\"\"",
+        ),
+        (Newline, newline),
+        (Symbol, "print!"),
+        (Symbol, "multi_line_b"),
+        (Newline, newline),
+        (Newline, newline),
+        (Symbol, "complex_string"),
+        (Equal, "="),
+        (StrLit, "\"\"\"\\    \0\r\n\\\"\"\""),
+        (Newline, newline),
+        (Symbol, "print!"),
+        (Symbol, "complex_string"),
+        (EOF, ""),
+    ];
     let mut tok: Token;
     for (id, i) in token_array.into_iter().enumerate() {
         print!("{id:>03}: ");

--- a/compiler/erg_parser/tests/tokenize_test.rs
+++ b/compiler/erg_parser/tests/tokenize_test.rs
@@ -367,6 +367,30 @@ line break\"\"\"",
         (Newline, newline),
         (Symbol, "print!"),
         (Symbol, "complex_string"),
+        (Newline, newline),
+        (Newline, newline),
+        (Symbol, "quotation_mark"),
+        (Equal, "="),
+        (StrLit, "\"\"\"\"\"\"\"\"\""),
+        (Newline, newline),
+        (Symbol, "print!"),
+        (Symbol, "quotation_mark"),
+        (Newline, newline),
+        (Newline, newline),
+        (Symbol, "quotation_marks"),
+        (Equal, "="),
+        (
+            StrLit,
+            "\"\"\"\"
+\"\"
+\"\"\"
+\"\"\"\"\"
+\"\"\"
+\"\"\"\"\"\"",
+        ),
+        (Newline, newline),
+        (Symbol, "print!"),
+        (Symbol, "quotation_marks"),
         (EOF, ""),
     ];
     let mut tok: Token;


### PR DESCRIPTION
Fixes #167.

Add method for multi-line strings and a file to test it.

A test for tokenizing multi-line strings will also be added.

Changes proposed in this PR:
- Add lex_multi_line_str() method
- Add multi-line string and string conditional branching
- Add test to ensure that the added methods function properly

@mtshiba
