### PR TITLE
Add links to subtitle in syntax dir 

### DIFF
--- a/doc/EN/syntax/21_lambda.md
+++ b/doc/EN/syntax/21_lambda.md
@@ -83,7 +83,7 @@ match res2:
     err: Error -> panic err.msg
 ```
 
-## Anonymous polycorrelation coefficient
+## Anonymous polymorphic functions
 
 ```python
 # same as id|T| x: T = x

--- a/doc/EN/syntax/indexes.md
+++ b/doc/EN/syntax/indexes.md
@@ -1,70 +1,74 @@
 # index
 
 See [here](../API/index.md) for APIs not in this index.
+
 See [here](../terms.md) for terminology.
 
 ## symbol
 
-* [!](./07_side_effect.md)
-  * !-type → [mutable type](./type/18_mut.md)
-* ? → error handling
-* [&#35;](./00_basic.md/#comment)
-* [$](./type/advanced/shared.md)
+* ! → [side&sbsp;effect](./07_side_effect.md)
+  * !-type → [mutable&nbsp;type](./type/18_mut.md)
+* ? → [error&nbsp;handling](./30_error_handling.md)
+* &#35; → [Str](./00_basic.md/#comment)
+* $ → [shared](./type/advanced/shared.md)
 * %
 * &
   * &&
 * [&prime;&nbsp;(single&nbsp;quote)](./20_naming_rule.md#literal-identifiers)
 * [&quot;&nbsp;(double&nbsp;quote)](./01_literal.md#str-literal)
-* &lpar;&rpar; → Tuple
+* &lpar;&rpar; → [Tuple](./11_tuple.md)
 * &ast;
-  * [*-less multiplication](./01_literal.md/#less-multiplication)
-* &plus; (prefix) → operator
+  * &ast; → [*-less&nbsp;multiplication](./01_literal.md/#less-multiplication)
+* &plus; (prefix) → [operator](./06_operator.md)
   * &plus;_ → &plus; (prefix)
-* &plus; (infix) → operator
+* &plus; (infix) → [operator](./06_operator.md)
+* &plus; (infix) → [Trait](./type/03_trait.md)
 * ,
 * &minus; (prefix)
   * &minus;_ → &minus; (prefix)
-* &minus; (infix)
-  * &minus;> → anonymous&nbsp;function
-* . → Visibility
-  * [...&nbsp;function](./04_function.md#variable-length-arguments)
+* &minus; (infix) → [operator](./06_operator.md)
+* &minus; (infix) → [Trait](./type/03_trait.md)
+  * &minus;> → [anonymous&nbsp;function](./21_lambda.md)
+* . → [Visibility](./19_visibility.md)
   * [...&nbsp;assignment](./28_spread_syntax.md)
   * [...&nbsp;Extract&nbsp;assignment](./28_spread_syntax.md#extract-assignment)
+  * [...&nbsp;function](./04_function.md#variable-length-arguments)
 * /
 * :
-  * : → Colon application style
-  * : → Keyword Arguments
-  * : → variable
-  * :: → visibility
-  * [:=](./04_function.md#default-parameters)
+  * : → [Colon&nbsp;application&nbsp;style](./04_function.md)
+  * : → [Declaration](./03_declaration.md.md)
+  * : → [Keyword&bsp;Arguments](./04_function.md)
+  * :: → [visibility](./19_visibility.md)
+  * := → [default&nbsp;parameters](./04_function.md)
 * ;
 * &lt;
-  * &lt;: → Subtype specification
+  * &lt;: → [Subtype&nbsp;specification](./type/02_basic.md)
   * &lt;&lt;
   * &lt;=
-* = → Variable
+* = → [Variable](./19_visibility.md)
   * ==
-  * => → procedure
+  * => → [procedure](./08_procedure.md)
 * &gt;
   * &gt;&gt;
   * &gt;=
-* @ → decorator
-* [] → Array
-* \
+* @ → [decorator](./29_decorator.md)
+* [] → [Array](./10_array.md)
+* \ → [Indention](./00_basic.md)
+* \ → [Str](./01_literal.md)
 * ^
   * ^^
-* _ → Type erasure
+* _ → [Type&nbsp;erasure](./type/advanced/erasure.md)
   * &#95;+&#95; → &plus; (infix)
   * &#95;-&#95; → &minus; (infix)
 * [``&nbsp;(back&nbsp;quote)](./22_subroutine.md#operator)
 * {}
-  * {} type → Structure type 
+  * {} type → [Structure&nbsp;type](./type/01_type_system.md)
 * {:}
-* [{=}](./type/01_type_system.md#classification)
-  * [{=}&nbsp;type](./13_record.md#empty-record)
+* {=} → [Type&nbsp;System](./type/01_type_system.md#classification)
+  * {=} → [&nbsp;type](./13_record.md#empty-record)
 * |
-  * || → Quantified Dependent Type
-  * || → Trait
+  * || → [Quantified&nbsp;Dependent&nbsp;Type](./type/advanced/quantified_dependent.md)
+  * || → [Trait](./type/03_trait.md)
 * ~
 
 ## alphabet
@@ -74,13 +78,15 @@ See [here](../terms.md) for terminology.
 * [Add]
 * [alias](type/02_basic.md#aliasing)
 * [Aliasing](./type/02_basic.md#aliasing)
+* [All&nbsp;symmetric&nbsp;types](./type/15_quantified.md#all-symmetric-types)
 * [algebraic&nbsp;type](./type/13_algebraic.md)
-* And
-* and → Trait Inclusion
+* [And]
+* [and]
 * [anonymous&nbsp;function](./21_lambda.md)
 * [Anonymous&nbsp;polycorrelation&nbsp;coefficient](./21_lambda.md#anonymous-polycorrelation-coefficient)
+* anonymous type → [Type&nbsp;System](./type/01_type_system.md)
 * [Array](./10_array.md)
-* assert
+* [assert]
 * [Attach](./29_decorator.md#attach)
 * [attribute](type/09_attributive.md)
 * [Attribute&nbsp;definitions](./type/02_basic.md#attribute-definitions)
@@ -88,7 +94,7 @@ See [here](../terms.md) for terminology.
 
 ### B
 
-* Base → Class
+* Base → [Class](./type/04_class.md)
 * [Boolean](./01_literal.md#boolean-object)
 * [Boolean&nbsp;Object](./01_literal.md#boolean-object)
 * [borrow](./18_ownership.md#borrow)
@@ -101,6 +107,8 @@ See [here](../terms.md) for terminology.
 * [Compile-time&nbsp;functions](./04_function.md#compile-time-functions)
 * [circular&nbsp;references](./18_ownership.md#circular-references)
 * [Class](./type/04_class.md)
+* [Class&nbsp;Relationship](./type/04_class.md#class-relationships)
+* [Class&nbsp;upcasting](./type/16_subtyping.md#class-upcasting)
 * [Colon&nbsp;application&nbsp;style](./04_function.md#colon-application-style)
 * [Closure](./23_closure.md)
 * [Compound Literals](./01_literal.md#compound-literals)
@@ -118,16 +126,18 @@ See [here](../terms.md) for terminology.
 * [Default&nbsp;parameters](./04_function.md#default-parameters)
 * [Del](./02_name.md#delete-an-variable)
 * [Dependent&nbsp;Type](./type/14_dependent.md)
-* [Deconstructing a record]
+* [Deconstructing&nbsp;a&nbsp;record](13_record.md#deconstructing-a-record)
 * Deprecated
 * [Dict](./12_dict.md)
-* [Diff](./type/13_algebraic.md#diff) 
+* [Diff](./type/13_algebraic.md#diff)
+* [Difference&nbsp;from&nbsp;Data&nbsp;Class](./type/04_class.md#difference-from-data-class)
 * [Difference&nbsp;from&nbsp;structural&nbsp;types](type/04_class.md#difference-from-structural-types)
 * distinct
 * [Downcasting](./type/17_type_casting.md#downcasting)
 
 ### E
 
+* [Empty&nbsp;Record](./13_record.md#empty-record)
 * [Enum&nbsp;Class](./type/04_class.md#enum-class)
 * [Enum&nbsp;type](./type/11_enum.md)
 * [Enumerated,&nbsp;Interval&nbsp;and&nbsp;Shift&nbsp;Types](./type/12_refinement.md#enumerated-interval-and-sift-types)
@@ -158,14 +168,16 @@ See [here](../terms.md) for terminology.
 
 * [id](./09_builtin_procs.md#id)
 * [if](./05_builtin_funcs.md#if)
-* import → Integration with Python
+* import → [Integration&nbsp;with&nbsp;Python](32_integration_with_Python.md)
 * [impl](./29_decorator.md#impl)
-* in
+* [in]
 * [Indention](./00_basic.md#indentation)
 * [Instant&nbsp;Block](./13_record.md#instant-block)
+* [Instance&nbsp;and&nbsp;class&nbsp;attributes](./type/04_class.md#instance-and-class-attributes)
+* [Implementing&nbsp;and&nbsp;resolving&nbsp;duplicate&nbsp;traits&nbsp;in&nbsp;the&nbsp;API](type/03_trait.md#implementing-and-resolving-duplicate-traits-in-the-api)
 * [inheritable](./29_decorator.md#inheritable)
 * [inheritance](./type/05_inheritance.md)
-* [Inheritance of Enumerated Classes](./type/05_inheritance.md#inheritance)
+* [Inheritance&nbsp;of&nbsp;Enumerated&nbsp;Classes](./type/05_inheritance.md#inheritance)
 * [Int](./01_literal.md)
 * [Integration&nbsp;with&nbsp;Python](./32_integration_with_Python.md)
 * [Interval&nbsp;Type](./type/10_interval.md)
@@ -181,17 +193,17 @@ See [here](../terms.md) for terminology.
 
 ### L
 
-* lambda → [anonymous function]
-* let-polymorphism → [rank 1 polymorphism]
+* lambda → [anonymous&nbsp;function](./21_lambda.md)
+* let-polymorphism → [rank&nbsp;1&nbsp;polymorphism]
 * [Literal&nbsp;Identifiers](./20_naming_rule.md#literal-identifiers)
-* log
+* log → [side&nbsp;effect](./07_side_effect.md)
 
 ### M
 
-* match
+* [match]
 * [Marker&sbsp;Trait](./type/advanced/marker_trait.md)
 * [Method](./07_side_effect.md#methods)
-* Modifier → decorator
+* Modifier → [decorator](./29_decorator.md)
 * [module](./24_module.md)
 * [Multiple&nbsp;Inheritance](type/05_inheritance.md#multiple-inheritance)
 * [Multi-layer&nbsp;(multi-level)&nbsp;Inheritance](type/05_inheritance.md#multi-layer-multi-level-inheritance)
@@ -202,19 +214,21 @@ See [here](../terms.md) for terminology.
 ### N
 
 * [Nat](./01_literal.md#int-literal)
-* Never
+* [Never]
 * [New&nbsp;type](./type/advanced/newtype.md)
 * [Heterogeneous&nbsp;Dict](./12_dict.md#heterogeneous-dict)
 * None → [None&nbsp;Object]
-* Not
-* not → Trait inclusion
+* [None&nbsp;Object]
+* Nominal&nbsp;Subtyping → [Class](./type/04_class.md)
+* [Not]
+* [not]
 
 ### O
 
 * [Object](./25_object_system.md)
-* Option
-* Or
-* or
+* [Option]
+* [Or]
+* [or]
 * [Ord]
 * [ownership&nbsp;system](./18_ownership.md)
 * [Overloading](./type/advanced/overloading.md)
@@ -232,25 +246,27 @@ See [here](../terms.md) for terminology.
 * [print!]
 * [Procedures](./08_procedure.md)
 * [Projection%nbsp;Type](./type/advanced/projection.md)
-* Python → Integration with Python
+* Python → [Integration&nbsp;with&nbsp;Python](./32_integration_with_Python.md)
 
 ### Q
 
 * [Quantified&nbsp;Type](./type/15_quantified.md)
 * [Quantified&nbsp;Dependent&nbsp;Type](./type/advanced/quantified_dependent.md)
+* [Quantified&nbsp;Types&nbsp;and&nbsp;Dependent&nbsp;Types](./type/15_quantified.md#quantified-types-and-dependent-types)
 
 ### R
 
 * [Range&nbsp;Object](./01_literal.md#range-object)
-* ref
-* ref!
+* [ref]
+* [ref!]
 * [Record](./13_record.md)
-* [Recursive%nbsp;functions](./04_function.md#recursive-functions)
+* [Record&nbsp;Type&nbsp;Composite](./type/09_attributive.mda12_refinement.md)
+* [Recursive&nbsp;functions](./04_function.md#recursive-functions)
 * [Refinement&nbsp;pattern](./type/12_refinement.md#refinement-pattern)
 * [Refinement&nbsp;Type](./type/12_refinement.md)
 * [replication](./18_ownership.md#replication)
 * [Replacing&nbsp;Traits](./type/05_inheritance.md#replacing-traits-or-what-looks-like-it)
-* Result → error handling
+* Result → [error&nbsp;handling](./30_error_handling.md)
 * [Rewriting&nbsp;Inherited&nbsp;Attributes](./type/05_inheritance.md#rewriting-inherited-attributes)
 * rootobj
 
@@ -258,7 +274,7 @@ See [here](../terms.md) for terminology.
 
 * [Script](./00_basic.md#scripts)
 * [Selecting&nbsp;Patches](./type/07_patch.md#selecting-patches)
-* self → Visibility
+* self → [Visibility](./19_visibility.md)
 * [Self](./type/advanced/special.md)
 * [Shared&nbsp;Reference](./type/advanced/shared.md)
 * [side-effect](./07_side_effect.md)
@@ -266,11 +282,16 @@ See [here](../terms.md) for terminology.
 * [Spread&nbsp;assignment](./28_spread_syntax.md)
 * [special&nbsp;type&nbsp;variables](./type/advanced/special.md#special-type-variables)
 * [Stack&nbsp;trace](30_error_handling.md#stack-trace)
-* [Structure type](./type/01_type_system.md#structure-type-anonymous-type)
+* [Structure&nbsp;type](./type/01_type_system.md#structure-type-anonymous-type)
 * [Structural&nbsp;Patch](./type/07_patch.md#structural-patch)
+* [Structural&nbsp;Trait](./type/03_trait.md#structural-traits)
+* Structural&nbsp;Subtyping → [Patch](./type/07_patch.md)
+* [Structural&nbsp;types&nbsp;and&nbsp;class&nbsp;type&nbsp;relationships](./type/16_subtyping.md#structural-types-and-class-type-relationships)
 * [Str](./01_literal.md#str-literal)
 * [Subtyping](./type/16_subtyping.md)
+* [Subtyping&nbsp;of&nbsp;subroutines](./type/16_subtyping.md#subtyping-of-subroutines)
 * [Subtype&nbsp;specification](./type/02_basic.md#subtype-specification)
+* [Subtyping&nbsp;of&nbsp;Polymorphic&nbsp;Function Types](./type/15_quantified.md#subtyping-of-polymorphic-function-types)
 * [Subroutine&nbsp;Signatures](./22_subroutine.md)
 
 ### T
@@ -278,15 +299,17 @@ See [here](../terms.md) for terminology.
 * [Test](./29_decorator.md#test)
 * [Traits](./type/03_trait.md)
 * [Trait&nbsp;inclusion](./type/03_trait.md#trait-inclusion)
-* True → Boolean Object
+* True → [Boolean&nbsp;Object]
 * [True&nbsp;Algebraic&nbsp;type](./type/13_algebraic.md#true-algebraic-type)
-* [Type](./type/01_type_system.md)
+* [Type]
 * [type](./15_type.md)
+* [Type&nbsp;arguments&nbsp;in&nbsp;method&nbsp;definitions](./type/15_quantified.md#type-arguments-in-method-definitions)
 * [Type&nbsp;Bound](./type/19_bound.md)
 * [Type&nbsp;Definitions](./type/01_type_system.md#type-definitions)
 * [Type&nbsp;erasure](./type/advanced/erasure.md)
 * [Type&nbsp;Inference&nbsp;System](./type/01_type_system.md#type-inference-system)
 * [Type&nbsp;specification](./type/02_basic.md#type-specification)
+* [Type&nbsp;System](./type/01_type_system.md)
 * [Type&nbsp;Widening](./type/advanced/widening.md)
 * [Tuple](./11_tuple.md)
 
@@ -305,7 +328,7 @@ See [here](../terms.md) for terminology.
 
 ### W
 
-* [while!]
+* [while]
 
 ### X
 

--- a/doc/EN/syntax/indexes.md
+++ b/doc/EN/syntax/indexes.md
@@ -38,8 +38,8 @@ Also, see [here](../terms.md) for terminology.
 * /
 * :
   * : → [Colon&nbsp;application&nbsp;style](./04_function.md)
-  * : → [Declaration](./03_declaration.md.md)
-  * : → [Keyword&nbsp;Arguments](./04_function.md)
+  * : → [Type ascription](./03_declaration.md.md)
+  * : → [Keyword&nbsp;arguments](./04_function.md)
   * :: → [private variable modifier](./19_visibility.md)
   * := → [default&nbsp;parameters](./04_function.md)
 * ;
@@ -47,6 +47,8 @@ Also, see [here](../terms.md) for terminology.
   * &lt;: → [Subtype&nbsp;specification](./type/02_basic.md)
   * &lt;&lt;
   * &lt;=
+  * &lt;.. → [left-open range operator](./01_literal.md/#range-object)
+  * &lt;..&lt; → [open range operator](./01_literal.md/#range-object)
 * = → [Variable](./19_visibility.md)
   * ==
   * => → [anonymous procedure operator](./08_procedure.md)
@@ -55,8 +57,7 @@ Also, see [here](../terms.md) for terminology.
   * &gt;=
 * @ → [decorator](./29_decorator.md)
 * [] → [Array](./10_array.md)
-* \ → [Indention](./00_basic.md)
-* \ → [Str](./01_literal.md)
+* \ → [Escaping](./00_basic.md)
 * ^
   * ^^
 * _ → [Type&nbsp;erasure](./type/advanced/erasure.md)
@@ -65,7 +66,6 @@ Also, see [here](../terms.md) for terminology.
 * [``&nbsp;(back&nbsp;quote)](./22_subroutine.md#operator)
 * {}
   * [{} type](./type/01_type_system.md)
-* {:}
 * {=} → [Type&nbsp;System](./type/01_type_system.md#classification)
   * [{=}&nbsp;type](./13_record.md#empty-record)
 * |
@@ -84,34 +84,33 @@ Also, see [here](../terms.md) for terminology.
 * [And]
 * [and]
 * [anonymous&nbsp;function](./21_lambda.md)
-* [Anonymous&nbsp;polycorrelation&nbsp;coefficient](./21_lambda.md#anonymous-polycorrelation-coefficient)
-* anonymous type → [Type&nbsp;System](./type/01_type_system.md)
+* anonymous type → [Type&nbsp;system](./type/01_type_system.md)
 * [Array](./10_array.md)
 * [assert]
 * [Attach](./29_decorator.md#attach)
 * [attribute](type/09_attributive.md)
 * [Attribute&nbsp;definitions](./type/02_basic.md#attribute-definitions)
-* [Attribute&nbsp;Type](./type/09_attributive.md)
+* [Attribute&nbsp;type](./type/09_attributive.md)
 
 ### B
 
 * [Bool, Boolean](./01_literal.md#boolean-object)
-* [Boolean&nbsp;Object](./01_literal.md#boolean-object)
-* [borrow](./18_ownership.md#borrow)
+* [Boolean&nbsp;object](./01_literal.md#boolean-object)
+* [borrowing](./18_ownership.md#borrow)
 
 ### C
 
 * [Cast](./type/17_type_casting.md)
 * [Comments](./00_basic.md#comments)
-* [Complex&nbsp;Object](./01_literal.md#complex-object)
+* [Complex&nbsp;object](./01_literal.md#complex-object)
 * [Compile-time&nbsp;functions](./04_function.md#compile-time-functions)
 * [circular&nbsp;references](./18_ownership.md#circular-references)
 * [Class](./type/04_class.md)
-* [Class&nbsp;Relationship](./type/04_class.md#class-relationships)
+* [Class&nbsp;relationship](./type/04_class.md#class-relationships)
 * [Class&nbsp;upcasting](./type/16_subtyping.md#class-upcasting)
 * [Colon&nbsp;application&nbsp;style](./04_function.md#colon-application-style)
 * [Closure](./23_closure.md)
-* [Compound Literals](./01_literal.md#compound-literals)
+* [Compound literals](./01_literal.md#compound-literals)
 * [Complement](./type/13_algebraic.md#complement)
 * [Comprehension](./27_comprehension.md)
 * [constant](./17_mutability.md#constant)
@@ -125,33 +124,30 @@ Also, see [here](../terms.md) for terminology.
 * [decorator](./29_decorator.md)
 * [Default&nbsp;parameters](./04_function.md#default-parameters)
 * [Del](./02_name.md#delete-an-variable)
-* [Dependent&nbsp;Type](./type/14_dependent.md)
-* [Deconstructing&nbsp;a&nbsp;record](13_record.md#deconstructing-a-record)
+* [Dependent&nbsp;type](./type/14_dependent.md)
 * Deprecated
 * [Dict](./12_dict.md)
 * [Diff](./type/13_algebraic.md#diff)
-* [Difference&nbsp;from&nbsp;Data&nbsp;Class](./type/04_class.md#difference-from-data-class)
-* [Difference&nbsp;from&nbsp;structural&nbsp;types](type/04_class.md#difference-from-structural-types)
 * distinct
 * [Downcasting](./type/17_type_casting.md#downcasting)
 
 ### E
 
-* [Empty&nbsp;Record](./13_record.md#empty-record)
-* [Enum&nbsp;Class](./type/04_class.md#enum-class)
+* [Empty&nbsp;record](./13_record.md#empty-record)
+* [Enum&nbsp;class](./type/04_class.md#enum-class)
 * [Enum&nbsp;type](./type/11_enum.md)
-* [Enumerated,&nbsp;Interval&nbsp;and&nbsp;Refinement&nbsp;Types](./type/12_refinement.md#enumerated-interval-and-refinement-types)
+* [Enumerated,&nbsp;Interval&nbsp;and&nbsp;Refinement&nbsp;types](./type/12_refinement.md#enumerated-interval-and-refinement-types)
 * [error&nbsp;handling](./30_error_handling.md)
 * [Existential&nbsp;type](./type/advanced/existential.md)
-* [Exponential&nbsp;Literal](./01_literal.md#exponential-literal)
+* [Exponential&nbsp;literal](./01_literal.md#exponential-literal)
 * [Extract&nbsp;assignment](./28_spread_syntax.md#extract-assignment)
 
 ### F
 
-* False → [Boolean Object](./01_literal.md#boolean-object)
-* [Float&sbsp;Object](./01_literal.md#float-object)
+* False → [Boolean object](./01_literal.md#boolean-object)
+* [Float&nbsp;object](./01_literal.md#float-object)
 * [for](./05_builtin_funcs.md#for)
-* [For-All&nbsp;Patch](./type/07_patch.md#for-all-patch)
+* [For-All&nbsp;patch](./type/07_patch.md#for-all-patch)
 * [freeze](./18_ownership.md#freeze)
 * [Function](./04_function.md)
 * [Function&nbsp;definition&nbsp;with&nbsp;multiple patterns](./04_function.md#function-definition-with-multiple-patterns)
@@ -172,12 +168,10 @@ Also, see [here](../terms.md) for terminology.
 * [impl](./29_decorator.md#impl)
 * [in]
 * [Indention](./00_basic.md#indentation)
-* [Instant&nbsp;Block](./13_record.md#instant-block)
-* [Instance&nbsp;and&nbsp;class&nbsp;attributes](./type/04_class.md#instance-and-class-attributes)
-* [Implementing&nbsp;and&nbsp;resolving&nbsp;duplicate&nbsp;traits&nbsp;in&nbsp;the&nbsp;API](type/03_trait.md#implementing-and-resolving-duplicate-traits-in-the-api)
+* [Instant&nbsp;block](./13_record.md#instant-block)
+* [Instance/class&nbsp;attributes](./type/04_class.md#instance-and-class-attributes)
 * [inheritable](./29_decorator.md#inheritable)
 * [inheritance](./type/05_inheritance.md)
-* [Inheritance&nbsp;of&nbsp;Enumerated&nbsp;Classes](./type/05_inheritance.md#inheritance)
 * [Int](./01_literal.md)
 * [Integration&nbsp;with&nbsp;Python](./32_integration_with_Python.md)
 * [Interval&nbsp;Type](./type/10_interval.md)
@@ -200,14 +194,14 @@ Also, see [here](../terms.md) for terminology.
 ### M
 
 * [match]
-* [Marker&nbsp;Trait](./type/advanced/marker_trait.md)
+* [Marker&nbsp;trait](./type/advanced/marker_trait.md)
 * [Method](./07_side_effect.md#methods)
 * Modifier → [decorator](./29_decorator.md)
 * [module](./24_module.md)
-* [Multiple&nbsp;Inheritance](type/05_inheritance.md#multiple-inheritance)
+* [Multiple&nbsp;inheritance](type/05_inheritance.md#multiple-inheritance)
 * [Multi-layer&nbsp;(multi-level)&nbsp;Inheritance](type/05_inheritance.md#multi-layer-multi-level-inheritance)
-* [Mutable&nbsp;Type](./type/18_mut.md)
-* [Mutable&nbsp;Structure&nbsp;Type](./type/advanced/mut_struct.md)
+* [Mutable&nbsp;type](./type/18_mut.md)
+* [Mutable&nbsp;structure&nbsp;type](./type/advanced/mut_struct.md)
 * [Mutability](./17_mutability.md)
 
 ### N
@@ -232,7 +226,7 @@ Also, see [here](../terms.md) for terminology.
 * [ownership&nbsp;system](./18_ownership.md)
 * [Overloading](./type/advanced/overloading.md)
 * [Overriding](./type/05_inheritance.md#overriding)
-* [Override&nbsp;in&nbsp;Trait](./type/03_trait.md#override-in-trait)
+* [Override&nbsp;in&nbsp;trait](./type/03_trait.md#override-in-trait)
 
 ### P
 
@@ -244,14 +238,13 @@ Also, see [here](../terms.md) for terminology.
 * [Predicate](./type/19_bound.md#predicate)
 * [print!]
 * [Procedures](./08_procedure.md)
-* [Projection&nbsp;Type](./type/advanced/projection.md)
+* [Projection&nbsp;type](./type/advanced/projection.md)
 * Python → [Integration&nbsp;with&nbsp;Python](./32_integration_with_Python.md)
 
 ### Q
 
-* [Quantified&nbsp;Type](./type/15_quantified.md)
-* [Quantified&nbsp;Dependent&nbsp;Type](./type/advanced/quantified_dependent.md)
-* [Quantified&nbsp;Types&nbsp;and&nbsp;Dependent&nbsp;Types](./type/15_quantified.md#quantified-types-and-dependent-types)
+* [Quantified&nbsp;type](./type/15_quantified.md)
+* [Quantified&nbsp;dependent&nbsp;type](./type/advanced/quantified_dependent.md)
 
 ### R
 
@@ -259,56 +252,53 @@ Also, see [here](../terms.md) for terminology.
 * [ref]
 * [ref!]
 * [Record](./13_record.md)
-* [Record&nbsp;Type&nbsp;Composite](./type/09_attributive.mda12_refinement.md)
 * [Recursive&nbsp;functions](./04_function.md#recursive-functions)
 * [Refinement&nbsp;pattern](./type/12_refinement.md#refinement-pattern)
-* [Refinement&nbsp;Type](./type/12_refinement.md)
+* [Refinement&nbsp;type](./type/12_refinement.md)
 * [replication](./18_ownership.md#replication)
-* [Replacing&nbsp;Traits](./type/05_inheritance.md#replacing-traits-or-what-looks-like-it)
+* [Replacing&nbsp;traits](./type/05_inheritance.md#replacing-traits-or-what-looks-like-it)
 * Result → [error&nbsp;handling](./30_error_handling.md)
-* [Rewriting&nbsp;Inherited&nbsp;Attributes](./type/05_inheritance.md#rewriting-inherited-attributes)
 
 ### S
 
 * [Script](./00_basic.md#scripts)
-* [Selecting&nbsp;Patches](./type/07_patch.md#selecting-patches)
 * self
 * [Self](./type/advanced/special.md)
-* [Shared&nbsp;Reference](./type/advanced/shared.md)
+* [Shared&nbsp;reference](./type/advanced/shared.md)
 * [side-effect](./07_side_effect.md)
-* [Smart&nbsp;Cast](./type/12_refinement.md#smart-cast)
+* [Smart&nbsp;cast](./type/12_refinement.md#smart-cast)
 * [Spread&nbsp;assignment](./28_spread_syntax.md)
 * [special&nbsp;type&nbsp;variables](./type/advanced/special.md#special-type-variables)
 * [Stack&nbsp;trace](30_error_handling.md#stack-trace)
 * [Structure&nbsp;type](./type/01_type_system.md#structure-type-anonymous-type)
-* [Structural&nbsp;Patch](./type/07_patch.md#structural-patch)
-* [Structural&nbsp;Trait](./type/03_trait.md#structural-traits)
-* [Structural&nbsp;Subtyping](./type/01_type_system.md#classification)
+* [Structural&nbsp;patch](./type/07_patch.md#structural-patch)
+* [Structural&nbsp;trait](./type/03_trait.md#structural-traits)
+* [Structural&nbsp;subtyping](./type/01_type_system.md#classification)
 * [Structural&nbsp;types&nbsp;and&nbsp;class&nbsp;type&nbsp;relationships](./type/16_subtyping.md#structural-types-and-class-type-relationships)
 * [Str](./01_literal.md#str-literal)
 * [Subtyping](./type/16_subtyping.md)
 * [Subtyping&nbsp;of&nbsp;subroutines](./type/16_subtyping.md#subtyping-of-subroutines)
 * [Subtype&nbsp;specification](./type/02_basic.md#subtype-specification)
-* [Subtyping&nbsp;of&nbsp;Polymorphic&nbsp;Function Types](./type/15_quantified.md#subtyping-of-polymorphic-function-types)
-* [Subroutine&nbsp;Signatures](./22_subroutine.md)
+* [Subtyping&nbsp;of&nbsp;polymorphic&nbsp;function types](./type/15_quantified.md#subtyping-of-polymorphic-function-types)
+* [Subroutine&nbsp;signatures](./22_subroutine.md)
 
 ### T
 
 * [Test](./29_decorator.md#test)
 * [Traits](./type/03_trait.md)
 * [Trait&nbsp;inclusion](./type/03_trait.md#trait-inclusion)
-* True → [Boolean&nbsp;Object](./01_literal.md#boolean-object)
-* [True&nbsp;Algebraic&nbsp;type](./type/13_algebraic.md#true-algebraic-type)
+* True → [Boolean&nbsp;object](./01_literal.md#boolean-object)
+* [True&nbsp;algebraic&nbsp;type](./type/13_algebraic.md#true-algebraic-type)
 * [Type]
 * [type](./15_type.md)
 * [Type&nbsp;arguments&nbsp;in&nbsp;method&nbsp;definitions](./type/15_quantified.md#type-arguments-in-method-definitions)
-* [Type&nbsp;Bound](./type/19_bound.md)
-* [Type&nbsp;Definitions](./type/01_type_system.md#type-definitions)
+* [Type&nbsp;bound](./type/19_bound.md)
+* [Type&nbsp;definitions](./type/01_type_system.md#type-definitions)
 * [Type&nbsp;erasure](./type/advanced/erasure.md)
-* [Type&nbsp;Inference&nbsp;System](./type/01_type_system.md#type-inference-system)
+* [Type&nbsp;inference&nbsp;system](./type/01_type_system.md#type-inference-system)
 * [Type&nbsp;specification](./type/02_basic.md#type-specification)
-* [Type&nbsp;System](./type/01_type_system.md)
-* [Type&nbsp;Widening](./type/advanced/widening.md)
+* [Type&nbsp;system](./type/01_type_system.md)
+* [Type&nbsp;widening](./type/advanced/widening.md)
 * [Tuple](./11_tuple.md)
 
 ### U
@@ -316,11 +306,10 @@ Also, see [here](../terms.md) for terminology.
 * [union](type/13_algebraic.md#union)
 * [Unit](./11_tuple.md#unit)
 * [Upcasting](type/17_type_casting.md#upcasting)
-* [Usage&nbsp;of&nbsp;Inheritance](./type/05_inheritance.md#usage-of-inheritance)
 
 ### V
 
-* [Value&nbsp;Type](./type/08_value.md)
+* [Value&nbsp;type](./type/08_value.md)
 * [Variable](./02_name.md)
 * [variable-length&nbsp;arguments](./04_function.md#variable-length-arguments)
 

--- a/doc/EN/syntax/indexes.md
+++ b/doc/EN/syntax/indexes.md
@@ -1,19 +1,20 @@
 # index
 
 See [here](../API/index.md) for APIs not in this index.
-See [here](../dev_guide/terms.md) for terminology.
+See [here](../terms.md) for terminology.
 
 ## symbol
 
-* !
-  * !-type → [mutable type](./type/mut.md)
+* [!](./07_side_effect.md)
+  * !-type → [mutable type](./type/18_mut.md)
 * [&#35;](./00_basic.md/#comment)
-* $
+* [$](./type/advanced/shared.md)
 * %
 * &
   * &&
-* &prime; (single quote)
-* &lpar;&rpar;
+* [&prime;&nbsp;(single&nbsp;quote)](./20_naming_rule.md#literal-identifiers)
+* [&quot;&nbsp;(double&nbsp;quote)](./01_literal.md#str-literal)
+* &lpar;&rpar; → Tuple
 * &ast;
   * [*-less multiplication](./01_literal.md/#less-multiplication)
 * &plus; (prefix)
@@ -23,11 +24,12 @@ See [here](../dev_guide/terms.md) for terminology.
 * &minus; (prefix)
   * &minus;_ → &minus; (prefix)
 * &minus; (infix)
-  * &minus;>
-* . → [Visibility]
+  * &minus;> → anonymous&nbsp;function
+* . → Visibility
 * /
 * :
-  * :: → [visibility]
+  * :: → visibility
+  * := → Default parameters
 * ;
 * &lt;
   * &lt;:
@@ -35,90 +37,140 @@ See [here](../dev_guide/terms.md) for terminology.
   * &lt;=
 * =
   * ==
-  * =>
+  * => → procedure
 * &gt;
   * &gt;&gt;
   * &gt;=
 * ?
-* @
-* []
+* @ → decorator
+* [] → Array
 * \
 * ^
   * ^^
 * _
   * &#95;+&#95; → &plus; (infix)
   * &#95;-&#95; → &minus; (infix)
-*``
+* [``&nbsp;(back&nbsp;quote)](./22_subroutine.md#operator)
 * {}
-  * {} type
-* {:}
-* {=}
-  * {=} type
+  * {} type → Compound literals
+* {:} → Set
+* {=} → Record
+  * {=} type → Record
 * |
-  * ||
+  * || → Quantified Dependent Type
 * ~
 
 ## alphabet
 
 ### A
 
-* algebraic&nbsp;type
+* [Add](../API/types/traits/Add(R%2CO).md)
+* [alias](type/02_basic.md#aliasing)
+* [algebraic&nbsp;type](./type/13_algebraic.md)
 * And
 * and
+* [anonymous&nbsp;function](./21_lambda.md)
+* [Array](./10_array.md)
 * assert
-* attribute
+* [Attach](./29_decorator.md#attach)
+* [attribute](type/09_attributive.md)
+* [Attribute&nbsp;Type](./type/09_attributive.md)
 
 ### B
 
 * Base
 * Bool
+* [borrow](18_ownership.md#borrow)
 
 ### C
 
-* Class
+* [Cast](./type/17_type_casting.md)
+* [circular&nbsp;references](./18_ownership.md#circular-references)
+* [Class](./type/04_class.md)
+* [Closure](./23_closure.md)
+* [Compound Literals](./01_literal.md#compound-literals)
+* [Complement](./type/13_algebraic.md#complement)
+* [Comprehension](./27_comprehension.md)
+* [constant](./17_mutability.md#constant)
+* [constants](./02_name.md#constants)
+* [Context](./30_error_handling.md#context)
 
 ### D
 
+* [Declaration](./03_declaration.md)
+* [decorator](./29_decorator.md)
+* [Default&nbsp;parameters](./04_function.md#default-parameters)
+* [Dependent&nbsp;Type](./type/14_dependent.md)
 * Deprecated
+* [Dict](./12_dict.md)
+* [Diff](./type/13_algebraic.md#diff) 
 * distinct
+* [Downcasting](./type/17_type_casting.md#downcasting)
 
 ### E
 
-* enum&nbsp;type
-* Eq
-* Erg
+* [Enum&nbsp;type](./type/11_enum.md)
+* [Enumerated,&nbsp;Interval&nbsp;and&nbsp;Shift&nbsp;Types](./type/12_refinement.md#enumerated-interval-and-sift-types)
+* [Eq](../API/types/traits/Eq.md)
+* [Erg](../faq_general.md)
+* [error&nbsp;handling](./30_error_handling.md)
+* [Existential&nbsp;type](./type/advanced/existential.md)
+* [Extract&nbsp;assignment](./28_spread_syntax.md#extract-assignment)
 
 ### F
 
-* for
+* [for](./05_builtin_funcs.md#for)
+* [freeze](./18_ownership.md#freeze)
+* [Function](./04_function.md)
 
 ### G
+
+* [GADTs(Generalized&nbsp;Algebraic&nbsp;Data&nbsp;Types)](./type/advanced/GADTs.md)
+* [Generator](./34_generator.md)
+* [Glue Patch](./type/07_patch.md#glue-patch)
 
 ### H
 
 ### I
 
-* if
+* [if](./05_builtin_funcs.md#if)
 * import
+* [impl](./29_decorator.md#impl)
 * in
-* Int
+* [inheritable](./29_decorator.md#inheritable)
+* [inheritance](./type/05_inheritance.md)
+* [Int](./01_literal.md)
+* [Interval&nbsp;Type](./type/10_interval.md)
+* [Intersection](./type/13_algebraic.md#intersection)
+* [Iterator](./16_iterator.md)
 
 ### J
 
 ### K
 
+ * [Keyword&nbsp;arguments](./04_function.md#keyword-arguments)
+ * [Kind](./type/advanced/kind.md)
+
 ### L
 
+* lambda → [anonymous function]
 * let-polymorphism → [rank 1 polymorphism]
 * log
 
 ### M
 
 * match
+* [Marker&sbsp;Trait](./type/advanced/marker_trait.md)
+* [Method](./07_side_effect.md#methods)
+* Modifier → decorator
+* [module](./24_module.md)
+* [Mutable&nbsp;Type](./type/18_mut.md)
+* [Mutable&nbsp;Structure&nbsp;Type](./type/advanced/mut_struct.md)
 
 ### N
 
-* Nat
+* 
+* [Nat](./01_literal.md#int-literal)
 * Never
 * None
 * None
@@ -127,47 +179,83 @@ See [here](../dev_guide/terms.md) for terminology.
 
 ### O
 
+* [Object](./25_object_system.md)
 * Option
 * Or
 * or
-* Ord
+* [Ord](../API/types/traits/Ord.md)
+* [ownership&nbsp;system](./18_ownership.md)
+  * ownership
 
 ### P
 
-* panic
+* [panic](./30_error_handling.md#panic)
+* [Patch](./type/07_patch.md)
+* [Phantom&nbsp;class](./type/advanced/phantom.md)
+* [pipeline&nbsp;operator](./31_pipeline.md)
 * [print!](./../API/procs.md#print)
-* Python
+* [Procedures](./08_procedure.md)
+* [Projection%nbsp;Type](./type/advanced/projection.md)
+* [Python](../python/index.md)
 
 ### Q
+
+* [Quantified&nbsp;Type](./type/15_quantified.md)
+* [Quantified&nbsp;Dependent&nbsp;Type](./type/advanced/quantified_dependent.md)
 
 ### R
 
 * ref
 * ref!
+* [Record](./13_record.md)
+* [Recursive%nbsp;functions](./04_function.md#recursive-functions)
+* [Refinement&nbsp;pattern](./type/12_refinement.md#refinement-pattern)
+* [Refinement&nbsp;Type](./type/12_refinement.md)
+* [replication](./18_ownership.md#replication)
 * Result
 * rootobj
 
 ### S
 
+* [Selecting&nbsp;Patches](./type/07_patch.md#selecting-patches)
 * self
 * [Self](./type/special.md)
+* [Shared&nbsp;Reference](./type/advanced/shared.md)
 * [side-effect](./07_side_effect.md)
-* Str
+* [Smart&nbsp;Cast](./type/12_refinement.md#smart-cast)
+* [Spread&nbsp;assignment](./28_spread_syntax.md)
+* [stack&nbsp;trace](30_error_handling.md#stack-trace)
+* [Str](./01_literal.md#str-literal)
+* [Subtyping](./type/16_subtyping.md)
+* [Subtype&nbsp;specification](./type/02_basic.md#subtype-specification)
+* [Subroutine&nbsp;Signatures](./22_subroutine.md)
 
 ### T
 
-* Traits
+* [Test](./29_decorator.md#test)
+* [Traits](./type/03_trait.md)
 * True
-* Type
-* type
+* [True&nbsp;Algebraic&nbsp;type](./type/13_algebraic.md#true-algebraic-type)
+* [Type](./type/01_type_system.md)
+* [type](./15_type.md)
+* [Type erasure](./type/advanced/erasure.md)
+* [Tuple](./11_tuple.md)
 
 ### U
 
+* [union](type/13_algebraic.md#union)
+* unit → Tuple
+* [Upcasting](type/17_type_casting.md#upcasting)
+
 ### V
+
+* [Value&nbsp;Type](./type/08_value.md)
+* [Variable](./02_name.md)
+* [variable-length&nbsp;arguments](./04_function.md#variable-length-arguments)
 
 ### W
 
-* while!
+* [while!](../API/procs.md#while-cond-bool-block---nonetype)
 
 ### X
 

--- a/doc/EN/syntax/indexes.md
+++ b/doc/EN/syntax/indexes.md
@@ -6,7 +6,7 @@ See [here](../terms.md) for terminology.
 
 ## symbol
 
-* ! → [side&sbsp;effect](./07_side_effect.md)
+* ! → [side&nbsp;effect](./07_side_effect.md)
   * !-type → [mutable&nbsp;type](./type/18_mut.md)
 * ? → [error&nbsp;handling](./30_error_handling.md)
 * &#35; → [Str](./00_basic.md/#comment)
@@ -37,7 +37,7 @@ See [here](../terms.md) for terminology.
 * :
   * : → [Colon&nbsp;application&nbsp;style](./04_function.md)
   * : → [Declaration](./03_declaration.md.md)
-  * : → [Keyword&bsp;Arguments](./04_function.md)
+  * : → [Keyword&nbsp;Arguments](./04_function.md)
   * :: → [visibility](./19_visibility.md)
   * := → [default&nbsp;parameters](./04_function.md)
 * ;
@@ -62,13 +62,12 @@ See [here](../terms.md) for terminology.
   * &#95;-&#95; → &minus; (infix)
 * [``&nbsp;(back&nbsp;quote)](./22_subroutine.md#operator)
 * {}
-  * {} type → [Structure&nbsp;type](./type/01_type_system.md)
+  * [{} type](./type/01_type_system.md)
 * {:}
 * {=} → [Type&nbsp;System](./type/01_type_system.md#classification)
-  * {=} → [&nbsp;type](./13_record.md#empty-record)
+  * [{=}&nbsp;type](./13_record.md#empty-record)
 * |
-  * || → [Quantified&nbsp;Dependent&nbsp;Type](./type/advanced/quantified_dependent.md)
-  * || → [Trait](./type/03_trait.md)
+  * || → [Type variable list](./type/advanced/)
 * ~
 
 ## alphabet
@@ -94,8 +93,7 @@ See [here](../terms.md) for terminology.
 
 ### B
 
-* Base → [Class](./type/04_class.md)
-* [Boolean](./01_literal.md#boolean-object)
+* [Bool, Boolean](./01_literal.md#boolean-object)
 * [Boolean&nbsp;Object](./01_literal.md#boolean-object)
 * [borrow](./18_ownership.md#borrow)
 
@@ -140,7 +138,7 @@ See [here](../terms.md) for terminology.
 * [Empty&nbsp;Record](./13_record.md#empty-record)
 * [Enum&nbsp;Class](./type/04_class.md#enum-class)
 * [Enum&nbsp;type](./type/11_enum.md)
-* [Enumerated,&nbsp;Interval&nbsp;and&nbsp;Shift&nbsp;Types](./type/12_refinement.md#enumerated-interval-and-sift-types)
+* [Enumerated,&nbsp;Interval&nbsp;and&nbsp;Refinement&nbsp;Types](./type/12_refinement.md#enumerated-interval-and-refinement-types)
 * [error&nbsp;handling](./30_error_handling.md)
 * [Existential&nbsp;type](./type/advanced/existential.md)
 * [Exponential&nbsp;Literal](./01_literal.md#exponential-literal)
@@ -148,7 +146,7 @@ See [here](../terms.md) for terminology.
 
 ### F
 
-* False → Boolean Object
+* False → [Boolean Object](./01_literal.md#boolean-object)
 * [Float&sbsp;Object](./01_literal.md#float-object)
 * [for](./05_builtin_funcs.md#for)
 * [For-All&nbsp;Patch](./type/07_patch.md#for-all-patch)
@@ -168,7 +166,7 @@ See [here](../terms.md) for terminology.
 
 * [id](./09_builtin_procs.md#id)
 * [if](./05_builtin_funcs.md#if)
-* import → [Integration&nbsp;with&nbsp;Python](32_integration_with_Python.md)
+* [import](./33_package_system.md)
 * [impl](./29_decorator.md#impl)
 * [in]
 * [Indention](./00_basic.md#indentation)
@@ -188,8 +186,8 @@ See [here](../terms.md) for terminology.
 
 ### K
 
- * [Keyword&nbsp;arguments](./04_function.md#keyword-arguments)
- * [Kind](./type/advanced/kind.md)
+* [Keyword&nbsp;arguments](./04_function.md#keyword-arguments)
+* [Kind](./type/advanced/kind.md)
 
 ### L
 
@@ -201,7 +199,7 @@ See [here](../terms.md) for terminology.
 ### M
 
 * [match]
-* [Marker&sbsp;Trait](./type/advanced/marker_trait.md)
+* [Marker&nbsp;Trait](./type/advanced/marker_trait.md)
 * [Method](./07_side_effect.md#methods)
 * Modifier → [decorator](./29_decorator.md)
 * [module](./24_module.md)
@@ -245,7 +243,7 @@ See [here](../terms.md) for terminology.
 * [Predicate](./type/19_bound.md#predicate)
 * [print!]
 * [Procedures](./08_procedure.md)
-* [Projection%nbsp;Type](./type/advanced/projection.md)
+* [Projection&nbsp;Type](./type/advanced/projection.md)
 * Python → [Integration&nbsp;with&nbsp;Python](./32_integration_with_Python.md)
 
 ### Q
@@ -274,7 +272,7 @@ See [here](../terms.md) for terminology.
 
 * [Script](./00_basic.md#scripts)
 * [Selecting&nbsp;Patches](./type/07_patch.md#selecting-patches)
-* self → [Visibility](./19_visibility.md)
+* self
 * [Self](./type/advanced/special.md)
 * [Shared&nbsp;Reference](./type/advanced/shared.md)
 * [side-effect](./07_side_effect.md)
@@ -285,7 +283,7 @@ See [here](../terms.md) for terminology.
 * [Structure&nbsp;type](./type/01_type_system.md#structure-type-anonymous-type)
 * [Structural&nbsp;Patch](./type/07_patch.md#structural-patch)
 * [Structural&nbsp;Trait](./type/03_trait.md#structural-traits)
-* Structural&nbsp;Subtyping → [Patch](./type/07_patch.md)
+* [Structural&nbsp;Subtyping](./type/01_type_system.md#classification)
 * [Structural&nbsp;types&nbsp;and&nbsp;class&nbsp;type&nbsp;relationships](./type/16_subtyping.md#structural-types-and-class-type-relationships)
 * [Str](./01_literal.md#str-literal)
 * [Subtyping](./type/16_subtyping.md)
@@ -299,7 +297,7 @@ See [here](../terms.md) for terminology.
 * [Test](./29_decorator.md#test)
 * [Traits](./type/03_trait.md)
 * [Trait&nbsp;inclusion](./type/03_trait.md#trait-inclusion)
-* True → [Boolean&nbsp;Object]
+* True → [Boolean&nbsp;Object](./01_literal.md#boolean-object)
 * [True&nbsp;Algebraic&nbsp;type](./type/13_algebraic.md#true-algebraic-type)
 * [Type]
 * [type](./15_type.md)
@@ -335,4 +333,3 @@ See [here](../terms.md) for terminology.
 ### Y
 
 ### Z
-

--- a/doc/EN/syntax/indexes.md
+++ b/doc/EN/syntax/indexes.md
@@ -7,6 +7,7 @@ See [here](../terms.md) for terminology.
 
 * [!](./07_side_effect.md)
   * !-type → [mutable type](./type/18_mut.md)
+* ? → error handling
 * [&#35;](./00_basic.md/#comment)
 * [$](./type/advanced/shared.md)
 * %
@@ -17,129 +18,156 @@ See [here](../terms.md) for terminology.
 * &lpar;&rpar; → Tuple
 * &ast;
   * [*-less multiplication](./01_literal.md/#less-multiplication)
-* &plus; (prefix)
+* &plus; (prefix) → operator
   * &plus;_ → &plus; (prefix)
-* &plus; (infix)
+* &plus; (infix) → operator
 * ,
 * &minus; (prefix)
   * &minus;_ → &minus; (prefix)
 * &minus; (infix)
   * &minus;> → anonymous&nbsp;function
 * . → Visibility
+  * [...&nbsp;function](./04_function.md#variable-length-arguments)
+  * [...&nbsp;assignment](./28_spread_syntax.md)
+  * [...&nbsp;Extract&nbsp;assignment](./28_spread_syntax.md#extract-assignment)
 * /
 * :
+  * : → Colon application style
+  * : → Keyword Arguments
+  * : → variable
   * :: → visibility
-  * := → Default parameters
+  * [:=](./04_function.md#default-parameters)
 * ;
 * &lt;
-  * &lt;:
+  * &lt;: → Subtype specification
   * &lt;&lt;
   * &lt;=
-* =
+* = → Variable
   * ==
   * => → procedure
 * &gt;
   * &gt;&gt;
   * &gt;=
-* ?
 * @ → decorator
 * [] → Array
 * \
 * ^
   * ^^
-* _
+* _ → Type erasure
   * &#95;+&#95; → &plus; (infix)
   * &#95;-&#95; → &minus; (infix)
 * [``&nbsp;(back&nbsp;quote)](./22_subroutine.md#operator)
 * {}
-  * {} type → Compound literals
-* {:} → Set
-* {=} → Record
-  * {=} type → Record
+  * {} type → Structure type 
+* {:}
+* [{=}](./type/01_type_system.md#classification)
+  * [{=}&nbsp;type](./13_record.md#empty-record)
 * |
   * || → Quantified Dependent Type
+  * || → Trait
 * ~
 
 ## alphabet
 
 ### A
 
-* [Add](../API/types/traits/Add(R%2CO).md)
+* [Add]
 * [alias](type/02_basic.md#aliasing)
+* [Aliasing](./type/02_basic.md#aliasing)
 * [algebraic&nbsp;type](./type/13_algebraic.md)
 * And
-* and
+* and → Trait Inclusion
 * [anonymous&nbsp;function](./21_lambda.md)
+* [Anonymous&nbsp;polycorrelation&nbsp;coefficient](./21_lambda.md#anonymous-polycorrelation-coefficient)
 * [Array](./10_array.md)
 * assert
 * [Attach](./29_decorator.md#attach)
 * [attribute](type/09_attributive.md)
+* [Attribute&nbsp;definitions](./type/02_basic.md#attribute-definitions)
 * [Attribute&nbsp;Type](./type/09_attributive.md)
 
 ### B
 
-* Base
-* Bool
-* [borrow](18_ownership.md#borrow)
+* Base → Class
+* [Boolean](./01_literal.md#boolean-object)
+* [Boolean&nbsp;Object](./01_literal.md#boolean-object)
+* [borrow](./18_ownership.md#borrow)
 
 ### C
 
 * [Cast](./type/17_type_casting.md)
+* [Comments](./00_basic.md#comments)
+* [Complex&nbsp;Object](./01_literal.md#complex-object)
+* [Compile-time&nbsp;functions](./04_function.md#compile-time-functions)
 * [circular&nbsp;references](./18_ownership.md#circular-references)
 * [Class](./type/04_class.md)
+* [Colon&nbsp;application&nbsp;style](./04_function.md#colon-application-style)
 * [Closure](./23_closure.md)
 * [Compound Literals](./01_literal.md#compound-literals)
 * [Complement](./type/13_algebraic.md#complement)
 * [Comprehension](./27_comprehension.md)
 * [constant](./17_mutability.md#constant)
-* [constants](./02_name.md#constants)
+* [Constants](./02_name.md#constants)
 * [Context](./30_error_handling.md#context)
 
 ### D
 
+* [Data&nbsp;type](./type/01_type_system.md#data-type)
 * [Declaration](./03_declaration.md)
 * [decorator](./29_decorator.md)
 * [Default&nbsp;parameters](./04_function.md#default-parameters)
+* [Del](./02_name.md#delete-an-variable)
 * [Dependent&nbsp;Type](./type/14_dependent.md)
+* [Deconstructing a record]
 * Deprecated
 * [Dict](./12_dict.md)
 * [Diff](./type/13_algebraic.md#diff) 
+* [Difference&nbsp;from&nbsp;structural&nbsp;types](type/04_class.md#difference-from-structural-types)
 * distinct
 * [Downcasting](./type/17_type_casting.md#downcasting)
 
 ### E
 
+* [Enum&nbsp;Class](./type/04_class.md#enum-class)
 * [Enum&nbsp;type](./type/11_enum.md)
 * [Enumerated,&nbsp;Interval&nbsp;and&nbsp;Shift&nbsp;Types](./type/12_refinement.md#enumerated-interval-and-sift-types)
-* [Eq](../API/types/traits/Eq.md)
-* [Erg](../faq_general.md)
 * [error&nbsp;handling](./30_error_handling.md)
 * [Existential&nbsp;type](./type/advanced/existential.md)
+* [Exponential&nbsp;Literal](./01_literal.md#exponential-literal)
 * [Extract&nbsp;assignment](./28_spread_syntax.md#extract-assignment)
 
 ### F
 
+* False → Boolean Object
+* [Float&sbsp;Object](./01_literal.md#float-object)
 * [for](./05_builtin_funcs.md#for)
+* [For-All&nbsp;Patch](./type/07_patch.md#for-all-patch)
 * [freeze](./18_ownership.md#freeze)
 * [Function](./04_function.md)
+* [Function&nbsp;definition&nbsp;with&nbsp;multiple patterns](./04_function.md#function-definition-with-multiple-patterns)
 
 ### G
 
 * [GADTs(Generalized&nbsp;Algebraic&nbsp;Data&nbsp;Types)](./type/advanced/GADTs.md)
 * [Generator](./34_generator.md)
-* [Glue Patch](./type/07_patch.md#glue-patch)
+* [Glue&nbsp;Patch](./type/07_patch.md#glue-patch)
 
 ### H
 
 ### I
 
+* [id](./09_builtin_procs.md#id)
 * [if](./05_builtin_funcs.md#if)
-* import
+* import → Integration with Python
 * [impl](./29_decorator.md#impl)
 * in
+* [Indention](./00_basic.md#indentation)
+* [Instant&nbsp;Block](./13_record.md#instant-block)
 * [inheritable](./29_decorator.md#inheritable)
 * [inheritance](./type/05_inheritance.md)
+* [Inheritance of Enumerated Classes](./type/05_inheritance.md#inheritance)
 * [Int](./01_literal.md)
+* [Integration&nbsp;with&nbsp;Python](./32_integration_with_Python.md)
 * [Interval&nbsp;Type](./type/10_interval.md)
 * [Intersection](./type/13_algebraic.md#intersection)
 * [Iterator](./16_iterator.md)
@@ -155,6 +183,7 @@ See [here](../terms.md) for terminology.
 
 * lambda → [anonymous function]
 * let-polymorphism → [rank 1 polymorphism]
+* [Literal&nbsp;Identifiers](./20_naming_rule.md#literal-identifiers)
 * log
 
 ### M
@@ -164,18 +193,21 @@ See [here](../terms.md) for terminology.
 * [Method](./07_side_effect.md#methods)
 * Modifier → decorator
 * [module](./24_module.md)
+* [Multiple&nbsp;Inheritance](type/05_inheritance.md#multiple-inheritance)
+* [Multi-layer&nbsp;(multi-level)&nbsp;Inheritance](type/05_inheritance.md#multi-layer-multi-level-inheritance)
 * [Mutable&nbsp;Type](./type/18_mut.md)
 * [Mutable&nbsp;Structure&nbsp;Type](./type/advanced/mut_struct.md)
+* [Mutability](./17_mutability.md)
 
 ### N
 
-* 
 * [Nat](./01_literal.md#int-literal)
 * Never
-* None
-* None
+* [New&nbsp;type](./type/advanced/newtype.md)
+* [Heterogeneous&nbsp;Dict](./12_dict.md#heterogeneous-dict)
+* None → [None&nbsp;Object]
 * Not
-* not
+* not → Trait inclusion
 
 ### O
 
@@ -183,20 +215,24 @@ See [here](../terms.md) for terminology.
 * Option
 * Or
 * or
-* [Ord](../API/types/traits/Ord.md)
+* [Ord]
 * [ownership&nbsp;system](./18_ownership.md)
-  * ownership
+* [Overloading](./type/advanced/overloading.md)
+* [Overriding](./type/05_inheritance.md#overriding)
+* [Override&nbsp;in&nbsp;Trait](./type/03_trait.md#override-in-trait)
 
 ### P
 
-* [panic](./30_error_handling.md#panic)
+* [Panic](./30_error_handling.md#panic)
 * [Patch](./type/07_patch.md)
+* [Pattern&nbsp;match](./26_pattern_matching.md)
 * [Phantom&nbsp;class](./type/advanced/phantom.md)
 * [pipeline&nbsp;operator](./31_pipeline.md)
-* [print!](./../API/procs.md#print)
+* [Predicate](./type/19_bound.md#predicate)
+* [print!]
 * [Procedures](./08_procedure.md)
 * [Projection%nbsp;Type](./type/advanced/projection.md)
-* [Python](../python/index.md)
+* Python → Integration with Python
 
 ### Q
 
@@ -205,6 +241,7 @@ See [here](../terms.md) for terminology.
 
 ### R
 
+* [Range&nbsp;Object](./01_literal.md#range-object)
 * ref
 * ref!
 * [Record](./13_record.md)
@@ -212,19 +249,25 @@ See [here](../terms.md) for terminology.
 * [Refinement&nbsp;pattern](./type/12_refinement.md#refinement-pattern)
 * [Refinement&nbsp;Type](./type/12_refinement.md)
 * [replication](./18_ownership.md#replication)
-* Result
+* [Replacing&nbsp;Traits](./type/05_inheritance.md#replacing-traits-or-what-looks-like-it)
+* Result → error handling
+* [Rewriting&nbsp;Inherited&nbsp;Attributes](./type/05_inheritance.md#rewriting-inherited-attributes)
 * rootobj
 
 ### S
 
+* [Script](./00_basic.md#scripts)
 * [Selecting&nbsp;Patches](./type/07_patch.md#selecting-patches)
-* self
-* [Self](./type/special.md)
+* self → Visibility
+* [Self](./type/advanced/special.md)
 * [Shared&nbsp;Reference](./type/advanced/shared.md)
 * [side-effect](./07_side_effect.md)
 * [Smart&nbsp;Cast](./type/12_refinement.md#smart-cast)
 * [Spread&nbsp;assignment](./28_spread_syntax.md)
-* [stack&nbsp;trace](30_error_handling.md#stack-trace)
+* [special&nbsp;type&nbsp;variables](./type/advanced/special.md#special-type-variables)
+* [Stack&nbsp;trace](30_error_handling.md#stack-trace)
+* [Structure type](./type/01_type_system.md#structure-type-anonymous-type)
+* [Structural&nbsp;Patch](./type/07_patch.md#structural-patch)
 * [Str](./01_literal.md#str-literal)
 * [Subtyping](./type/16_subtyping.md)
 * [Subtype&nbsp;specification](./type/02_basic.md#subtype-specification)
@@ -234,18 +277,25 @@ See [here](../terms.md) for terminology.
 
 * [Test](./29_decorator.md#test)
 * [Traits](./type/03_trait.md)
-* True
+* [Trait&nbsp;inclusion](./type/03_trait.md#trait-inclusion)
+* True → Boolean Object
 * [True&nbsp;Algebraic&nbsp;type](./type/13_algebraic.md#true-algebraic-type)
 * [Type](./type/01_type_system.md)
 * [type](./15_type.md)
-* [Type erasure](./type/advanced/erasure.md)
+* [Type&nbsp;Bound](./type/19_bound.md)
+* [Type&nbsp;Definitions](./type/01_type_system.md#type-definitions)
+* [Type&nbsp;erasure](./type/advanced/erasure.md)
+* [Type&nbsp;Inference&nbsp;System](./type/01_type_system.md#type-inference-system)
+* [Type&nbsp;specification](./type/02_basic.md#type-specification)
+* [Type&nbsp;Widening](./type/advanced/widening.md)
 * [Tuple](./11_tuple.md)
 
 ### U
 
 * [union](type/13_algebraic.md#union)
-* unit → Tuple
+* [Unit](./11_tuple.md#unit)
 * [Upcasting](type/17_type_casting.md#upcasting)
+* [Usage&nbsp;of&nbsp;Inheritance](./type/05_inheritance.md#usage-of-inheritance)
 
 ### V
 
@@ -255,7 +305,7 @@ See [here](../terms.md) for terminology.
 
 ### W
 
-* [while!](../API/procs.md#while-cond-bool-block---nonetype)
+* [while!]
 
 ### X
 

--- a/doc/EN/syntax/indexes.md
+++ b/doc/EN/syntax/indexes.md
@@ -2,7 +2,7 @@
 
 See [here](../API/index.md) for APIs not in this index.
 
-See [here](../terms.md) for terminology.
+Also, see [here](../terms.md) for terminology.
 
 ## symbol
 
@@ -30,15 +30,17 @@ See [here](../terms.md) for terminology.
 * &minus; (infix) → [Trait](./type/03_trait.md)
   * &minus;> → [anonymous&nbsp;function](./21_lambda.md)
 * . → [Visibility](./19_visibility.md)
-  * [...&nbsp;assignment](./28_spread_syntax.md)
-  * [...&nbsp;Extract&nbsp;assignment](./28_spread_syntax.md#extract-assignment)
-  * [...&nbsp;function](./04_function.md#variable-length-arguments)
+  * .. → [closed range operator](./01_literal.md/#range-object)
+  * ..< → [right-open range operator](./01_literal.md/#range-object)
+  * ...
+    * ... → [Extract&nbsp;assignment](./28_spread_syntax.md#extract-assignment)
+    * ... → [Variable-length arguments](./04_function.md#variable-length-arguments)
 * /
 * :
   * : → [Colon&nbsp;application&nbsp;style](./04_function.md)
   * : → [Declaration](./03_declaration.md.md)
   * : → [Keyword&nbsp;Arguments](./04_function.md)
-  * :: → [visibility](./19_visibility.md)
+  * :: → [private variable modifier](./19_visibility.md)
   * := → [default&nbsp;parameters](./04_function.md)
 * ;
 * &lt;
@@ -47,7 +49,7 @@ See [here](../terms.md) for terminology.
   * &lt;=
 * = → [Variable](./19_visibility.md)
   * ==
-  * => → [procedure](./08_procedure.md)
+  * => → [anonymous procedure operator](./08_procedure.md)
 * &gt;
   * &gt;&gt;
   * &gt;=
@@ -194,7 +196,6 @@ See [here](../terms.md) for terminology.
 * lambda → [anonymous&nbsp;function](./21_lambda.md)
 * let-polymorphism → [rank&nbsp;1&nbsp;polymorphism]
 * [Literal&nbsp;Identifiers](./20_naming_rule.md#literal-identifiers)
-* log → [side&nbsp;effect](./07_side_effect.md)
 
 ### M
 
@@ -266,7 +267,6 @@ See [here](../terms.md) for terminology.
 * [Replacing&nbsp;Traits](./type/05_inheritance.md#replacing-traits-or-what-looks-like-it)
 * Result → [error&nbsp;handling](./30_error_handling.md)
 * [Rewriting&nbsp;Inherited&nbsp;Attributes](./type/05_inheritance.md#rewriting-inherited-attributes)
-* rootobj
 
 ### S
 

--- a/doc/EN/syntax/type/06_nst_vs_sst.md
+++ b/doc/EN/syntax/type/06_nst_vs_sst.md
@@ -39,5 +39,5 @@ If you cannot decide which one to use, our recommendation is NST.
 SST requires abstraction skills to write code that does not break down in any use case. Good abstraction can lead to high productivity, but wrong abstraction (commonality by appearances) can lead to counterproductive results. (NSTs can reduce this risk by deliberately keeping abstraction to a minimum. If you are not a library implementor, it is not a bad idea to code only with NSTs.
 
 <p align='center'>
-    <a href='./04_class.md'>Previous</a> | <a href='./06_inheritance.md'>Next</a>
+    <a href='./05_inheritance.md'>Previous</a> | <a href='./07_patch.md'>Next</a>
 </p>

--- a/doc/EN/syntax/type/08_value.md
+++ b/doc/EN/syntax/type/08_value.md
@@ -35,3 +35,7 @@ Types classified as value types may be added in the future.
 ---
 
 <span id="1" style="font-size:x-small"><sup>1</sup> The term "value type" in Erg differs from the definition in other languages. There is no concept of memory within pure Erg semantics, and it is incorrect to state that it is a value type because it is placed on the stack, or that it is not a value type because it is actually a pointer. A value type only means that it is a `Value` type or its subtypes. [↩](#f1)</span>
+
+<p align='center'>
+    <a href='./07_patch.md'>Previous</a> | <a href='./09_attributive.md'>Next</a>
+</p>

--- a/doc/EN/syntax/type/09_attributive.md
+++ b/doc/EN/syntax/type/09_attributive.md
@@ -7,3 +7,7 @@ Types belonging to attribute types are not value types.
 
 It is possible to flatten Record types composited.
 For example, `{... {.name = Str; .age = Nat}; ... {.name = Str; .id = Nat}}` becomes `{.name = Str; .age = Nat; .id = Nat}`.
+
+<p align='center'>
+    <a href='./08_procedure.md'>Previous</a> | <a href='./10_interval.md'>Next</a>
+</p>

--- a/doc/EN/syntax/type/09_attributive.md
+++ b/doc/EN/syntax/type/09_attributive.md
@@ -9,5 +9,5 @@ It is possible to flatten Record types composited.
 For example, `{... {.name = Str; .age = Nat}; ... {.name = Str; .id = Nat}}` becomes `{.name = Str; .age = Nat; .id = Nat}`.
 
 <p align='center'>
-    <a href='./08_procedure.md'>Previous</a> | <a href='./10_interval.md'>Next</a>
+    <a href='./08_value.md'>Previous</a> | <a href='./10_interval.md'>Next</a>
 </p>

--- a/doc/EN/syntax/type/10_interval.md
+++ b/doc/EN/syntax/type/10_interval.md
@@ -34,3 +34,7 @@ A Range operator can be used for non-numeric types, as long as they are `Ord` im
 ```python
 Alphabet = "A".."z"
 ```
+
+<p align='center'>
+    <a href='./09_attributive.md'>Previous</a> | <a href='./11_enum.md'>Next</a>
+</p>

--- a/doc/EN/syntax/type/11_enum.md
+++ b/doc/EN/syntax/type/11_enum.md
@@ -83,3 +83,7 @@ OpaqueAbc = Class {inner = {"A", "B", "C"}}.
     new inner: {"A", "B", "C"} = Self.new {inner;}
 OpaqueAbc.new("A").is_uppercase() # TypeError
 ```
+
+<p align='center'>
+    <a href='./10_interval.md'>Previous</a> | <a href='./12_refinement.md'>Next</a>
+</p>

--- a/doc/EN/syntax/type/12_refinement.md
+++ b/doc/EN/syntax/type/12_refinement.md
@@ -3,7 +3,7 @@
 Refinement type is a type constrained by a predicate expression. Enumeration types and interval types are syntax sugar of refinement types.
 
 The standard form of a refinement type is `{Elem: Type | (Pred)*}`. This means that the type is a type whose elements are `Elem` satisfying `Pred`.
-The type that can be used for the sifting type is [Const type] only.
+The type that can be used for the refinement type is [Value type](./08_value.md) only.
 
 ```python
 Nat = 0.. _
@@ -53,7 +53,7 @@ match i:
 
 However, Erg cannot currently make sub-decisions such as `Even` because it was not `Odd`, etc.
 
-## Enumerated, Interval and Sift Types
+## Enumerated, Interval and Refinement Types
 
 The enumerative/interval types introduced before are syntax sugar of the refinement type.
 `{a, b, ...}` is `{I: Typeof(a) | I == a or I == b or ... }`, and `a..b` is desugarized to `{I: Typeof(a) | I >= a and I <= b}`.

--- a/doc/EN/syntax/type/12_refinement.md
+++ b/doc/EN/syntax/type/12_refinement.md
@@ -73,3 +73,7 @@ Just as `_: {X}` can be rewritten as `X` (constant pattern), `_: {X: T | Pred}` 
 Array(T, N | N >= 3)
     .m(&self) = ...
 ```
+
+<p align='center'>
+    <a href='./11_enum.md'>Previous</a> | <a href='./13_algebraic.md'>Next</a>
+</p>

--- a/doc/EN/syntax/type/13_algebraic.md
+++ b/doc/EN/syntax/type/13_algebraic.md
@@ -82,3 +82,7 @@ assert Int and Marker == And(Int, Marker)
 ```
 
 Diff, Complement types are not true algebraic types because they can always be simplified.
+
+<p align='center'>
+    <a href='./12_refinement.md'>Previous</a> | <a href='./14_dependent.md'>Next</a>
+</p>

--- a/doc/EN/syntax/type/14_dependent.md
+++ b/doc/EN/syntax/type/14_dependent.md
@@ -72,3 +72,7 @@ MyArray(T, N) = Inherit[T; N]
 # The type of self: Self(T, N) changes in conjunction with .array
 MyStruct!(T, N: Nat!) = Class {.array: [T; !N]}
 ```
+
+<p align='center'>
+    <a href='./12_refinement.md'>Previous</a> | <a href='./14_dependent.md'>Next</a>
+</p>

--- a/doc/EN/syntax/type/14_dependent.md
+++ b/doc/EN/syntax/type/14_dependent.md
@@ -74,5 +74,5 @@ MyStruct!(T, N: Nat!) = Class {.array: [T; !N]}
 ```
 
 <p align='center'>
-    <a href='./12_refinement.md'>Previous</a> | <a href='./14_dependent.md'>Next</a>
+    <a href='./13_algebraic.md'>Previous</a> | <a href='./15_quantified.md'>Next</a>
 </p>

--- a/doc/EN/syntax/type/15_quantified.md
+++ b/doc/EN/syntax/type/15_quantified.md
@@ -280,5 +280,5 @@ assert DepFn(Int).type() == Int # by DepFn
 ```
 
 <p align='center'>
-    <a href='./14_dependent.md'>Previous</a> | <a href='./16_iterator.md'>Next</a>
+    <a href='./14_dependent.md'>Previous</a> | <a href='./16_subtyping.md'>Next</a>
 </p>

--- a/doc/EN/syntax/type/15_quantified.md
+++ b/doc/EN/syntax/type/15_quantified.md
@@ -278,3 +278,7 @@ DepFn.
 assert (Int -> Int).type() == Int # by DepFn
 assert DepFn(Int).type() == Int # by DepFn
 ```
+
+<p align='center'>
+    <a href='./14_dependent.md'>Previous</a> | <a href='./16_iterator.md'>Next</a>
+</p>

--- a/doc/EN/syntax/type/16_subtyping.md
+++ b/doc/EN/syntax/type/16_subtyping.md
@@ -74,3 +74,7 @@ i as (Int or Str)
 i as (1..10)
 i as {I: Int | I >= 0}
 ```
+
+<p align='center'>
+    <a href='./15_quantified.md'>Previous</a> | <a href='./17_type_casting.md'>Next</a>
+</p>

--- a/doc/EN/syntax/type/17_type_casting.md
+++ b/doc/EN/syntax/type/17_type_casting.md
@@ -70,3 +70,7 @@ IntTryFromFloat.
             then: r.ceil()
             else: Error "conversion failed".
 ```
+
+<p align='center'>
+    <a href='./16_subtyping.md'>Previous</a> | <a href='./18_mut.md'>Next</a>
+</p>

--- a/doc/EN/syntax/type/18_mut.md
+++ b/doc/EN/syntax/type/18_mut.md
@@ -161,3 +161,7 @@ And for the type `T!` which has no internal structure, this instance is simply a
 ---
 
 <span id="1" style="font-size:x-small"><sup>1</sup> It is intentional that `T!` and `T` types have no special linguistic relationship. It's a design. If there is a relationship, for example, if the `T`/`T!` type exists in the namespace, it will not be possible to introduce the `T!`/`T` type from another module. Also, the mutable type is not uniquely defined for the immutable type. Given the definition `T = (U, V)`, the possible variable subtypes of `T!` are `(U!, V)` and `(U, V!)`. [↩](#f1)</span>
+
+<p align='center'>
+    <a href='./19_bound.md'>Previous</a> | <a href='./17_type_casting.md'>Next</a>
+</p>

--- a/doc/EN/syntax/type/18_mut.md
+++ b/doc/EN/syntax/type/18_mut.md
@@ -163,5 +163,5 @@ And for the type `T!` which has no internal structure, this instance is simply a
 <span id="1" style="font-size:x-small"><sup>1</sup> It is intentional that `T!` and `T` types have no special linguistic relationship. It's a design. If there is a relationship, for example, if the `T`/`T!` type exists in the namespace, it will not be possible to introduce the `T!`/`T` type from another module. Also, the mutable type is not uniquely defined for the immutable type. Given the definition `T = (U, V)`, the possible variable subtypes of `T!` are `(U!, V)` and `(U, V!)`. [↩](#f1)</span>
 
 <p align='center'>
-    <a href='./19_bound.md'>Previous</a> | <a href='./17_type_casting.md'>Next</a>
+    <a href='./17_type_casting.md'>Previous</a> | <a href='./19_bound.md'>Next</a>
 </p>

--- a/doc/EN/syntax/type/19_bound.md
+++ b/doc/EN/syntax/type/19_bound.md
@@ -18,5 +18,5 @@ GeneralizedOdd = {I | U; I <: Div(Nat, U); I % 2 == 0}
 ```
 
 <p align='center'>
-    <a href='./18_mut.md'>Previous</a> | <a href='./advanced.md'>Next</a>
+    <a href='./18_mut.md'>Previous</a> | Next
 </p>

--- a/doc/EN/syntax/type/19_bound.md
+++ b/doc/EN/syntax/type/19_bound.md
@@ -18,5 +18,5 @@ GeneralizedOdd = {I | U; I <: Div(Nat, U); I % 2 == 0}
 ```
 
 <p align='center'>
-    <a href='./18_mut.md'>Previous</a>
+    <a href='./18_mut.md'>Previous</a> | <a href='./advanced.md'>Next</a>
 </p>

--- a/doc/EN/syntax/type/19_bound.md
+++ b/doc/EN/syntax/type/19_bound.md
@@ -16,3 +16,7 @@ Odd = {I: Int | I % 2 == 1}
 R2Plus = {(L, R) | L, R: Ratio; L > 0 and R > 0}
 GeneralizedOdd = {I | U; I <: Div(Nat, U); I % 2 == 0}
 ```
+
+<p align='center'>
+    <a href='./18_mut.md'>Previous</a>
+</p>

--- a/doc/JA/syntax/indexes.md
+++ b/doc/JA/syntax/indexes.md
@@ -3,173 +3,332 @@
 [![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/indexes.md%26commit_hash%3D68054846e20b4cdb0e92e986b1b86fcc77de8bcd)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/indexes.md&commit_hash=68054846e20b4cdb0e92e986b1b86fcc77de8bcd)
 
 この索引にないAPIについては[こちら](../API/index.md)を参照してください。
-用語の意味については[こちら](../dev_guide/terms.md)を参照。
+
+用語の意味については[こちら](../terms.md)を参照。
 
 ## 記号
 
-* !
-  * !-type → [可変型](./type/mut.md)
-* [&#35;](./00_basic.md/#コメント)
-* $
+* ! → [side&nbsp;effect](./07_side_effect.md)
+  * !-type → [mutable&nbsp;type](./type/18_mut.md)
+* ? → [error&nbsp;handling](./30_error_handling.md)
+* &#35; → [Str](./00_basic.md/#comment)
+* $ → [shared](./type/advanced/shared.md)
 * %
 * &
   * &&
-* &prime; (single quote)
-* &lpar;&rpar;
+* [&prime;&nbsp;(single&nbsp;quote)](./20_naming_rule.md)
+* [&quot;&nbsp;(double&nbsp;quote)](./01_literal.md)
+* &lpar;&rpar; → [Tuple](./11_tuple.md)
 * &ast;
-  * [*-less multiplication](./01_literal.md/#less-multiplication)
-* &plus; (前置)
+  * &ast; → [*-less&nbsp;multiplication](./01_literal.md/#less-multiplication)
+* &plus; (前置) → [operator](./06_operator.md)
   * &plus;_ → &plus; (前置)
-* &plus; (中置)
+* &plus; (中置) → [operator](./06_operator.md)
+* &plus; (中置) → [Trait](./type/03_trait.md)
 * ,
 * &minus; (前置)
   * &minus;_ → &minus; (前置)
-* &minus; (中置)
-  * &minus;>
-* . → [可視性]
+* &minus; (中置) → [operator](./06_operator.md)
+* &minus; (中置) → [Trait](./type/03_trait.md)
+  * &minus;> → [anonymous&nbsp;function](./21_lambda.md)
+* . → [Visibility](./19_visibility.md)
+  * [...&nbsp;assignment](./28_spread_syntax.md)
+  * [...&nbsp;Extract&nbsp;assignment](./28_spread_syntax.md)
+  * [...&nbsp;function](./04_function.md)
 * /
 * :
-  * :: → [可視性]
+  * : → [Colon&nbsp;application&nbsp;style](./04_function.md)
+  * : → [Declaration](./03_declaration.md.md)
+  * : → [Keyword&nbsp;Arguments](./04_function.md)
+  * :: → [visibility](./19_visibility.md)
+  * := → [default&nbsp;parameters](./04_function.md)
 * ;
 * &lt;
-  * &lt;:
+  * &lt;: → [Subtype&nbsp;specification](./type/02_basic.md)
   * &lt;&lt;
   * &lt;=
-* =
+* = → [Variable](./19_visibility.md)
   * ==
-  * =>
+  * => → [procedure](./08_procedure.md)
 * &gt;
   * &gt;&gt;
   * &gt;=
-* ?
-* @
-* []
-* \
+* @ → [decorator](./29_decorator.md)
+* [] → [Array](./10_array.md)
+* \ → [Indention](./00_basic.md)
+* \ → [Str](./01_literal.md)
 * ^
   * ^^
-* _
-  * &#95;+&#95; → &plus; (中置)
-  * &#95;-&#95; → &minus; (中置)
-* ``
+* _ → [Type&nbsp;erasure](./type/advanced/erasure.md)
+  * &#95;+&#95; → &plus; (infix)
+  * &#95;-&#95; → &minus; (infix)
+* [``&nbsp;(back&nbsp;quote)](./22_subroutine.md)
 * {}
-  * {} type
+  * [{} type](./type/01_type_system.md)
 * {:}
-* {=}
-  * {=} type
+* {=} → [Type&nbsp;System](./type/01_type_system.md)
+  * [{=}&nbsp;type](./13_record.md)
 * |
-  * ||
+  * || → [Type variable list](./type/advanced/)
 * ~
 
 ## アルファベット
 
 ### A
 
-* [algebraic&nbsp;type]
+* [Add]
+* [alias](type/02_basic.md)
+* [Aliasing](./type/02_basic.md)
+* [All&nbsp;symmetric&nbsp;types](./type/15_quantified.md)
+* [algebraic&nbsp;type](./type/13_algebraic.md)
 * [And]
 * [and]
+* [anonymous&nbsp;function](./21_lambda.md)
+* [Anonymous&nbsp;polycorrelation&nbsp;coefficient](./21_lambda.md)
+* anonymous type → [Type&nbsp;System](./type/01_type_system.md)
+* [Array](./10_array.md)
 * [assert]
-* [attribute]
+* [Attach](./29_decorator.md)
+* [attribute](type/09_attributive.md)
+* [Attribute&nbsp;definitions](./type/02_basic.md)
+* [Attribute&nbsp;Type](./type/09_attributive.md)
 
 ### B
 
-* [Base]
-* [Bool]
+* [Bool, Boolean](./01_literal.md)
+* [Boolean&nbsp;Object](./01_literal.md)
+* [borrow](./18_ownership.md)
 
 ### C
 
-* [Class]
+* [Cast](./type/17_type_casting.md)
+* [Comments](./00_basic.md)
+* [Complex&nbsp;Object](./01_literal.md)
+* [Compile-time&nbsp;functions](./04_function.md)
+* [circular&nbsp;references](./18_ownership.md)
+* [Class](./type/04_class.md)
+* [Class&nbsp;Relationship](./type/04_class.md)
+* [Class&nbsp;upcasting](./type/16_subtyping.md)
+* [Colon&nbsp;application&nbsp;style](./04_function.md)
+* [Closure](./23_closure.md)
+* [Compound Literals](./01_literal.md)
+* [Complement](./type/13_algebraic.md)
+* [Comprehension](./27_comprehension.md)
+* [constant](./17_mutability.md)
+* [Constants](./02_name.md)
+* [Context](./30_error_handling.md)
 
 ### D
 
+* [Data&nbsp;type](./type/01_type_system.md)
+* [Declaration](./03_declaration.md)
+* [decorator](./29_decorator.md)
+* [Default&nbsp;parameters](./04_function.md)
+* [Del](./02_name.md)
+* [Dependent&nbsp;Type](./type/14_dependent.md)
+* [Deconstructing&nbsp;a&nbsp;record](13_record.md)
 * Deprecated
-* [distinct]
+* [Dict](./12_dict.md)
+* [Diff](./type/13_algebraic.md)
+* [Difference&nbsp;from&nbsp;Data&nbsp;Class](./type/04_class.md)
+* [Difference&nbsp;from&nbsp;structural&nbsp;types](type/04_class.md)
+* distinct
+* [Downcasting](./type/17_type_casting.md)
 
 ### E
 
-* [enum&nbsp;type]
-* [Eq]
-* [Erg]
+* [Empty&nbsp;Record](./13_record.md)
+* [Enum&nbsp;Class](./type/04_class.md)
+* [Enum&nbsp;type](./type/11_enum.md)
+* [Enumerated,&nbsp;Interval&nbsp;and&nbsp;Refinement&nbsp;Types](./type/12_refinement.md)
+* [error&nbsp;handling](./30_error_handling.md)
+* [Existential&nbsp;type](./type/advanced/existential.md)
+* [Exponential&nbsp;Literal](./01_literal.md)
+* [Extract&nbsp;assignment](./28_spread_syntax.md)
 
 ### F
 
-* [for]
+* False → [Boolean Object](./01_literal.md)
+* [Float&sbsp;Object](./01_literal.md)
+* [for](./05_builtin_funcs.md)
+* [For-All&nbsp;Patch](./type/07_patch.md)
+* [freeze](./18_ownership.md)
+* [Function](./04_function.md)
+* [Function&nbsp;definition&nbsp;with&nbsp;multiple patterns](./04_function.md)
 
 ### G
+
+* [GADTs(Generalized&nbsp;Algebraic&nbsp;Data&nbsp;Types)](./type/advanced/GADTs.md)
+* [Generator](./34_generator.md)
+* [Glue&nbsp;Patch](./type/07_patch.md)
 
 ### H
 
 ### I
 
-* [if]
-* [import]
+* [id](./09_builtin_procs.md)
+* [if](./05_builtin_funcs.md)
+* [import](./33_package_system.md)
+* [impl](./29_decorator.md)
 * [in]
-* [Int]
+* [Indention](./00_basic.md)
+* [Instant&nbsp;Block](./13_record.md)
+* [Instance&nbsp;and&nbsp;class&nbsp;attributes](./type/04_class.md)
+* [Implementing&nbsp;and&nbsp;resolving&nbsp;duplicate&nbsp;traits&nbsp;in&nbsp;the&nbsp;API](type/03_trait.md)
+* [inheritable](./29_decorator.md)
+* [inheritance](./type/05_inheritance.md)
+* [Inheritance&nbsp;of&nbsp;Enumerated&nbsp;Classes](./type/05_inheritance.md)
+* [Int](./01_literal.md)
+* [Integration&nbsp;with&nbsp;Python](./32_integration_with_Python.md)
+* [Interval&nbsp;Type](./type/10_interval.md)
+* [Intersection](./type/13_algebraic.md)
+* [Iterator](./16_iterator.md)
 
 ### J
 
 ### K
 
+* [Keyword&nbsp;arguments](./04_function.md)
+* [Kind](./type/advanced/kind.md)
+
 ### L
 
-* let-polymorphism → [ランク1多相]
-* [log]
+* lambda → [anonymous&nbsp;function](./21_lambda.md)
+* let-polymorphism → [rank&nbsp;1&nbsp;polymorphism]
+* [Literal&nbsp;Identifiers](./20_naming_rule.md)
+* log → [side&nbsp;effect](./07_side_effect.md)
 
 ### M
 
 * [match]
+* [Marker&nbsp;Trait](./type/advanced/marker_trait.md)
+* [Method](./07_side_effect.md)
+* Modifier → [decorator](./29_decorator.md)
+* [module](./24_module.md)
+* [Multiple&nbsp;Inheritance](type/05_inheritance.md)
+* [Multi-layer&nbsp;(multi-level)&nbsp;Inheritance](type/05_inheritance.md)
+* [Mutable&nbsp;Type](./type/18_mut.md)
+* [Mutable&nbsp;Structure&nbsp;Type](./type/advanced/mut_struct.md)
+* [Mutability](./17_mutability.md)
 
 ### N
 
-* [Nat]
-* Never
-* None
-* None
+* [Nat](./01_literal.md)
+* [Never]
+* [New&nbsp;type](./type/advanced/newtype.md)
+* [Heterogeneous&nbsp;Dict](./12_dict.md)
+* None → [None&nbsp;Object]
+* [None&nbsp;Object]
+* Nominal&nbsp;Subtyping → [Class](./type/04_class.md)
 * [Not]
 * [not]
 
 ### O
 
+* [Object](./25_object_system.md)
 * [Option]
 * [Or]
 * [or]
 * [Ord]
+* [ownership&nbsp;system](./18_ownership.md)
+* [Overloading](./type/advanced/overloading.md)
+* [Overriding](./type/05_inheritance.md)
+* [Override&nbsp;in&nbsp;Trait](./type/03_trait.md)
 
 ### P
 
-* panic
-* [print!](./../API/procs.md#print)
-* [Python]
+* [Panic](./30_error_handling.md)
+* [Patch](./type/07_patch.md)
+* [Pattern&nbsp;match](./26_pattern_matching.md)
+* [Phantom&nbsp;class](./type/advanced/phantom.md)
+* [pipeline&nbsp;operator](./31_pipeline.md)
+* [Predicate](./type/19_bound.md)
+* [print!]
+* [Procedures](./08_procedure.md)
+* [Projection&nbsp;Type](./type/advanced/projection.md)
+* Python → [Integration&nbsp;with&nbsp;Python](./32_integration_with_Python.md)
 
 ### Q
 
+* [Quantified&nbsp;Type](./type/15_quantified.md)
+* [Quantified&nbsp;Dependent&nbsp;Type](./type/advanced/quantified_dependent.md)
+* [Quantified&nbsp;Types&nbsp;and&nbsp;Dependent&nbsp;Types](./type/15_quantified.md)
+
 ### R
 
-* ref
-* ref!
-* [Result]
-* [rootobj]
+* [Range&nbsp;Object](./01_literal.md)
+* [ref]
+* [ref!]
+* [Record](./13_record.md)
+* [Record&nbsp;Type&nbsp;Composite](./type/09_attributive.mda12_refinement.md)
+* [Recursive&nbsp;functions](./04_function.md)
+* [Refinement&nbsp;pattern](./type/12_refinement.md)
+* [Refinement&nbsp;Type](./type/12_refinement.md)
+* [replication](./18_ownership.md)
+* [Replacing&nbsp;Traits](./type/05_inheritance.md)
+* Result → [error&nbsp;handling](./30_error_handling.md)
+* [Rewriting&nbsp;Inherited&nbsp;Attributes](./type/05_inheritance.md)
+* rootobj
 
 ### S
 
+* [Script](./00_basic.md)
+* [Selecting&nbsp;Patches](./type/07_patch.md)
 * self
-* [Self](./type/special.md)
+* [Self](./type/advanced/special.md)
+* [Shared&nbsp;Reference](./type/advanced/shared.md)
 * [side-effect](./07_side_effect.md)
-* [Str]
+* [Smart&nbsp;Cast](./type/12_refinement.md)
+* [Spread&nbsp;assignment](./28_spread_syntax.md)
+* [special&nbsp;type&nbsp;variables](./type/advanced/special.md)
+* [Stack&nbsp;trace](30_error_handling.md)
+* [Structure&nbsp;type](./type/01_type_system.md)
+* [Structural&nbsp;Patch](./type/07_patch.md)
+* [Structural&nbsp;Trait](./type/03_trait.md)
+* [Structural&nbsp;Subtyping](./type/01_type_system.md)
+* [Structural&nbsp;types&nbsp;and&nbsp;class&nbsp;type&nbsp;relationships](./type/16_subtyping.md)
+* [Str](./01_literal.md)
+* [Subtyping](./type/16_subtyping.md)
+* [Subtyping&nbsp;of&nbsp;subroutines](./type/16_subtyping.md)
+* [Subtype&nbsp;specification](./type/02_basic.md)
+* [Subtyping&nbsp;of&nbsp;Polymorphic&nbsp;Function Types](./type/15_quantified.md)
+* [Subroutine&nbsp;Signatures](./22_subroutine.md)
 
 ### T
 
-* Trait
-* [True]
+* [Test](./29_decorator.md)
+* [Traits](./type/03_trait.md)
+* [Trait&nbsp;inclusion](./type/03_trait.md)
+* True → [Boolean&nbsp;Object](./01_literal.md)
+* [True&nbsp;Algebraic&nbsp;type](./type/13_algebraic.md)
 * [Type]
-* [type]
+* [type](./15_type.md)
+* [Type&nbsp;arguments&nbsp;in&nbsp;method&nbsp;definitions](./type/15_quantified.md)
+* [Type&nbsp;Bound](./type/19_bound.md)
+* [Type&nbsp;Definitions](./type/01_type_system.md)
+* [Type&nbsp;erasure](./type/advanced/erasure.md)
+* [Type&nbsp;Inference&nbsp;System](./type/01_type_system.md)
+* [Type&nbsp;specification](./type/02_basic.md)
+* [Type&nbsp;System](./type/01_type_system.md)
+* [Type&nbsp;Widening](./type/advanced/widening.md)
+* [Tuple](./11_tuple.md)
 
 ### U
 
+* [union](type/13_algebraic.md)
+* [Unit](./11_tuple.md)
+* [Upcasting](type/17_type_casting.md)
+* [Usage&nbsp;of&nbsp;Inheritance](./type/05_inheritance.md)
+
 ### V
+
+* [Value&nbsp;Type](./type/08_value.md)
+* [Variable](./02_name.md)
+* [variable-length&nbsp;arguments](./04_function.md)
 
 ### W
 
-* [while!]
+* [while]
 
 ### X
 

--- a/doc/zh_CN/syntax/indexes.md
+++ b/doc/zh_CN/syntax/indexes.md
@@ -3,173 +3,332 @@
 [![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/indexes.md%26commit_hash%3D438bcb89ea692f219b30f3a3ba107888b23eae98)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/indexes.md&commit_hash=438bcb89ea692f219b30f3a3ba107888b23eae98)
 
 有关不在此索引中的 API，请参阅 [此处](../API/index.md)。
-有关术语，请参见 [此处](../dev_guide/terms.md)。
+
+有关术语，请参见 [此处](../terms.md)。
 
 ## 符号
 
-* !
-  * !-type → [可变性](./type/mut.md)
-* [&#35;](./00_basic.md/#comment)
-* $
+* ! → [side&nbsp;effect](./07_side_effect.md)
+  * !-type → [mutable&nbsp;type](./type/18_mut.md)
+* ? → [error&nbsp;handling](./30_error_handling.md)
+* &#35; → [Str](./00_basic.md/#comment)
+* $ → [shared](./type/advanced/shared.md)
 * %
 * &
   * &&
-* &prime; (single quote)
-* &lpar;&rpar;
+* [&prime;&nbsp;(single&nbsp;quote)](./20_naming_rule.md)
+* [&quot;&nbsp;(double&nbsp;quote)](./01_literal.md)
+* &lpar;&rpar; → [Tuple](./11_tuple.md)
 * &ast;
-  * [*-less multiplication](./01_literal.md/#less-multiplication)
-* &plus; (前置)
+  * &ast; → [*-less&nbsp;multiplication](./01_literal.md/#less-multiplication)
+* &plus; (前置) → [operator](./06_operator.md)
   * &plus;_ → &plus; (前置)
-* &plus; (中置)
+* &plus; (中置) → [operator](./06_operator.md)
+* &plus; (中置) → [Trait](./type/03_trait.md)
 * ,
 * &minus; (前置)
   * &minus;_ → &minus; (前置)
-* &minus; (中置)
-  * &minus;>
-* . → [可见性]
+* &minus; (中置) → [operator](./06_operator.md)
+* &minus; (中置) → [Trait](./type/03_trait.md)
+  * &minus;> → [anonymous&nbsp;function](./21_lambda.md)
+* . → [Visibility](./19_visibility.md)
+  * [...&nbsp;assignment](./28_spread_syntax.md)
+  * [...&nbsp;Extract&nbsp;assignment](./28_spread_syntax.md)
+  * [...&nbsp;function](./04_function.md)
 * /
 * :
-  * :: → [可见性]
+  * : → [Colon&nbsp;application&nbsp;style](./04_function.md)
+  * : → [Declaration](./03_declaration.md.md)
+  * : → [Keyword&nbsp;Arguments](./04_function.md)
+  * :: → [visibility](./19_visibility.md)
+  * := → [default&nbsp;parameters](./04_function.md)
 * ;
 * &lt;
-  * &lt;:
+  * &lt;: → [Subtype&nbsp;specification](./type/02_basic.md)
   * &lt;&lt;
   * &lt;=
-* =
+* = → [Variable](./19_visibility.md)
   * ==
-  * =>
+  * => → [procedure](./08_procedure.md)
 * &gt;
   * &gt;&gt;
   * &gt;=
-* ?
-* @
-* []
-* \
+* @ → [decorator](./29_decorator.md)
+* [] → [Array](./10_array.md)
+* \ → [Indention](./00_basic.md)
+* \ → [Str](./01_literal.md)
 * ^
   * ^^
-* _
+* _ → [Type&nbsp;erasure](./type/advanced/erasure.md)
   * &#95;+&#95; → &plus; (infix)
   * &#95;-&#95; → &minus; (infix)
-*``
+* [``&nbsp;(back&nbsp;quote)](./22_subroutine.md)
 * {}
-  * {} type
+  * [{} type](./type/01_type_system.md)
 * {:}
-* {=}
-  * {=} type
+* {=} → [Type&nbsp;System](./type/01_type_system.md)
+  * [{=}&nbsp;type](./13_record.md)
 * |
-  * ||
+  * || → [Type variable list](./type/advanced/)
 * ~
 
-## 字母
+## アルファベット
 
 ### A
 
-* algebraic&nbsp;type
-* And
-* and
-* assert
-* attribute
+* [Add]
+* [alias](type/02_basic.md)
+* [Aliasing](./type/02_basic.md)
+* [All&nbsp;symmetric&nbsp;types](./type/15_quantified.md)
+* [algebraic&nbsp;type](./type/13_algebraic.md)
+* [And]
+* [and]
+* [anonymous&nbsp;function](./21_lambda.md)
+* [Anonymous&nbsp;polycorrelation&nbsp;coefficient](./21_lambda.md)
+* anonymous type → [Type&nbsp;System](./type/01_type_system.md)
+* [Array](./10_array.md)
+* [assert]
+* [Attach](./29_decorator.md)
+* [attribute](type/09_attributive.md)
+* [Attribute&nbsp;definitions](./type/02_basic.md)
+* [Attribute&nbsp;Type](./type/09_attributive.md)
 
 ### B
 
-* Base
-* Bool
+* [Bool, Boolean](./01_literal.md)
+* [Boolean&nbsp;Object](./01_literal.md)
+* [borrow](./18_ownership.md)
 
 ### C
 
-* Class
+* [Cast](./type/17_type_casting.md)
+* [Comments](./00_basic.md)
+* [Complex&nbsp;Object](./01_literal.md)
+* [Compile-time&nbsp;functions](./04_function.md)
+* [circular&nbsp;references](./18_ownership.md)
+* [Class](./type/04_class.md)
+* [Class&nbsp;Relationship](./type/04_class.md)
+* [Class&nbsp;upcasting](./type/16_subtyping.md)
+* [Colon&nbsp;application&nbsp;style](./04_function.md)
+* [Closure](./23_closure.md)
+* [Compound Literals](./01_literal.md)
+* [Complement](./type/13_algebraic.md)
+* [Comprehension](./27_comprehension.md)
+* [constant](./17_mutability.md)
+* [Constants](./02_name.md)
+* [Context](./30_error_handling.md)
 
 ### D
 
+* [Data&nbsp;type](./type/01_type_system.md)
+* [Declaration](./03_declaration.md)
+* [decorator](./29_decorator.md)
+* [Default&nbsp;parameters](./04_function.md)
+* [Del](./02_name.md)
+* [Dependent&nbsp;Type](./type/14_dependent.md)
+* [Deconstructing&nbsp;a&nbsp;record](13_record.md)
 * Deprecated
+* [Dict](./12_dict.md)
+* [Diff](./type/13_algebraic.md)
+* [Difference&nbsp;from&nbsp;Data&nbsp;Class](./type/04_class.md)
+* [Difference&nbsp;from&nbsp;structural&nbsp;types](type/04_class.md)
 * distinct
+* [Downcasting](./type/17_type_casting.md)
 
 ### E
 
-* enum&nbsp;type
-* Eq
-* Erg
+* [Empty&nbsp;Record](./13_record.md)
+* [Enum&nbsp;Class](./type/04_class.md)
+* [Enum&nbsp;type](./type/11_enum.md)
+* [Enumerated,&nbsp;Interval&nbsp;and&nbsp;Refinement&nbsp;Types](./type/12_refinement.md)
+* [error&nbsp;handling](./30_error_handling.md)
+* [Existential&nbsp;type](./type/advanced/existential.md)
+* [Exponential&nbsp;Literal](./01_literal.md)
+* [Extract&nbsp;assignment](./28_spread_syntax.md)
 
 ### F
 
-* for
+* False → [Boolean Object](./01_literal.md)
+* [Float&sbsp;Object](./01_literal.md)
+* [for](./05_builtin_funcs.md)
+* [For-All&nbsp;Patch](./type/07_patch.md)
+* [freeze](./18_ownership.md)
+* [Function](./04_function.md)
+* [Function&nbsp;definition&nbsp;with&nbsp;multiple patterns](./04_function.md)
 
 ### G
+
+* [GADTs(Generalized&nbsp;Algebraic&nbsp;Data&nbsp;Types)](./type/advanced/GADTs.md)
+* [Generator](./34_generator.md)
+* [Glue&nbsp;Patch](./type/07_patch.md)
 
 ### H
 
 ### I
 
-* if
-* import
-* in
-* Int
+* [id](./09_builtin_procs.md)
+* [if](./05_builtin_funcs.md)
+* [import](./33_package_system.md)
+* [impl](./29_decorator.md)
+* [in]
+* [Indention](./00_basic.md)
+* [Instant&nbsp;Block](./13_record.md)
+* [Instance&nbsp;and&nbsp;class&nbsp;attributes](./type/04_class.md)
+* [Implementing&nbsp;and&nbsp;resolving&nbsp;duplicate&nbsp;traits&nbsp;in&nbsp;the&nbsp;API](type/03_trait.md)
+* [inheritable](./29_decorator.md)
+* [inheritance](./type/05_inheritance.md)
+* [Inheritance&nbsp;of&nbsp;Enumerated&nbsp;Classes](./type/05_inheritance.md)
+* [Int](./01_literal.md)
+* [Integration&nbsp;with&nbsp;Python](./32_integration_with_Python.md)
+* [Interval&nbsp;Type](./type/10_interval.md)
+* [Intersection](./type/13_algebraic.md)
+* [Iterator](./16_iterator.md)
 
 ### J
 
 ### K
 
+* [Keyword&nbsp;arguments](./04_function.md)
+* [Kind](./type/advanced/kind.md)
+
 ### L
 
-* let-polymorphism → [rank 1 polymorphism]
-* log
+* lambda → [anonymous&nbsp;function](./21_lambda.md)
+* let-polymorphism → [rank&nbsp;1&nbsp;polymorphism]
+* [Literal&nbsp;Identifiers](./20_naming_rule.md)
+* log → [side&nbsp;effect](./07_side_effect.md)
 
 ### M
 
-* match
+* [match]
+* [Marker&nbsp;Trait](./type/advanced/marker_trait.md)
+* [Method](./07_side_effect.md)
+* Modifier → [decorator](./29_decorator.md)
+* [module](./24_module.md)
+* [Multiple&nbsp;Inheritance](type/05_inheritance.md)
+* [Multi-layer&nbsp;(multi-level)&nbsp;Inheritance](type/05_inheritance.md)
+* [Mutable&nbsp;Type](./type/18_mut.md)
+* [Mutable&nbsp;Structure&nbsp;Type](./type/advanced/mut_struct.md)
+* [Mutability](./17_mutability.md)
 
 ### N
 
-* Nat
-* Never
-* None
-* None
-* Not
-* not
+* [Nat](./01_literal.md)
+* [Never]
+* [New&nbsp;type](./type/advanced/newtype.md)
+* [Heterogeneous&nbsp;Dict](./12_dict.md)
+* None → [None&nbsp;Object]
+* [None&nbsp;Object]
+* Nominal&nbsp;Subtyping → [Class](./type/04_class.md)
+* [Not]
+* [not]
 
 ### O
 
-* Option
-* Or
-* or
-* Ord
+* [Object](./25_object_system.md)
+* [Option]
+* [Or]
+* [or]
+* [Ord]
+* [ownership&nbsp;system](./18_ownership.md)
+* [Overloading](./type/advanced/overloading.md)
+* [Overriding](./type/05_inheritance.md)
+* [Override&nbsp;in&nbsp;Trait](./type/03_trait.md)
 
 ### P
 
-* panic
-* [print!](./../API/procs.md#print)
-* Python
+* [Panic](./30_error_handling.md)
+* [Patch](./type/07_patch.md)
+* [Pattern&nbsp;match](./26_pattern_matching.md)
+* [Phantom&nbsp;class](./type/advanced/phantom.md)
+* [pipeline&nbsp;operator](./31_pipeline.md)
+* [Predicate](./type/19_bound.md)
+* [print!]
+* [Procedures](./08_procedure.md)
+* [Projection&nbsp;Type](./type/advanced/projection.md)
+* Python → [Integration&nbsp;with&nbsp;Python](./32_integration_with_Python.md)
 
 ### Q
 
+* [Quantified&nbsp;Type](./type/15_quantified.md)
+* [Quantified&nbsp;Dependent&nbsp;Type](./type/advanced/quantified_dependent.md)
+* [Quantified&nbsp;Types&nbsp;and&nbsp;Dependent&nbsp;Types](./type/15_quantified.md)
+
 ### R
 
-* ref
-* ref!
-* Result
+* [Range&nbsp;Object](./01_literal.md)
+* [ref]
+* [ref!]
+* [Record](./13_record.md)
+* [Record&nbsp;Type&nbsp;Composite](./type/09_attributive.mda12_refinement.md)
+* [Recursive&nbsp;functions](./04_function.md)
+* [Refinement&nbsp;pattern](./type/12_refinement.md)
+* [Refinement&nbsp;Type](./type/12_refinement.md)
+* [replication](./18_ownership.md)
+* [Replacing&nbsp;Traits](./type/05_inheritance.md)
+* Result → [error&nbsp;handling](./30_error_handling.md)
+* [Rewriting&nbsp;Inherited&nbsp;Attributes](./type/05_inheritance.md)
 * rootobj
 
 ### S
 
+* [Script](./00_basic.md)
+* [Selecting&nbsp;Patches](./type/07_patch.md)
 * self
-* [Self](./type/special.md)
+* [Self](./type/advanced/special.md)
+* [Shared&nbsp;Reference](./type/advanced/shared.md)
 * [side-effect](./07_side_effect.md)
-* Str
+* [Smart&nbsp;Cast](./type/12_refinement.md)
+* [Spread&nbsp;assignment](./28_spread_syntax.md)
+* [special&nbsp;type&nbsp;variables](./type/advanced/special.md)
+* [Stack&nbsp;trace](30_error_handling.md)
+* [Structure&nbsp;type](./type/01_type_system.md)
+* [Structural&nbsp;Patch](./type/07_patch.md)
+* [Structural&nbsp;Trait](./type/03_trait.md)
+* [Structural&nbsp;Subtyping](./type/01_type_system.md)
+* [Structural&nbsp;types&nbsp;and&nbsp;class&nbsp;type&nbsp;relationships](./type/16_subtyping.md)
+* [Str](./01_literal.md)
+* [Subtyping](./type/16_subtyping.md)
+* [Subtyping&nbsp;of&nbsp;subroutines](./type/16_subtyping.md)
+* [Subtype&nbsp;specification](./type/02_basic.md)
+* [Subtyping&nbsp;of&nbsp;Polymorphic&nbsp;Function Types](./type/15_quantified.md)
+* [Subroutine&nbsp;Signatures](./22_subroutine.md)
 
 ### T
 
-* Traits
-* True
-* Type
-* type
+* [Test](./29_decorator.md)
+* [Traits](./type/03_trait.md)
+* [Trait&nbsp;inclusion](./type/03_trait.md)
+* True → [Boolean&nbsp;Object](./01_literal.md)
+* [True&nbsp;Algebraic&nbsp;type](./type/13_algebraic.md)
+* [Type]
+* [type](./15_type.md)
+* [Type&nbsp;arguments&nbsp;in&nbsp;method&nbsp;definitions](./type/15_quantified.md)
+* [Type&nbsp;Bound](./type/19_bound.md)
+* [Type&nbsp;Definitions](./type/01_type_system.md)
+* [Type&nbsp;erasure](./type/advanced/erasure.md)
+* [Type&nbsp;Inference&nbsp;System](./type/01_type_system.md)
+* [Type&nbsp;specification](./type/02_basic.md)
+* [Type&nbsp;System](./type/01_type_system.md)
+* [Type&nbsp;Widening](./type/advanced/widening.md)
+* [Tuple](./11_tuple.md)
 
 ### U
 
+* [union](type/13_algebraic.md)
+* [Unit](./11_tuple.md)
+* [Upcasting](type/17_type_casting.md)
+* [Usage&nbsp;of&nbsp;Inheritance](./type/05_inheritance.md)
+
 ### V
+
+* [Value&nbsp;Type](./type/08_value.md)
+* [Variable](./02_name.md)
+* [variable-length&nbsp;arguments](./04_function.md)
 
 ### W
 
-* while!
+* [while]
 
 ### X
 

--- a/doc/zh_TW/syntax/indexes.md
+++ b/doc/zh_TW/syntax/indexes.md
@@ -3,173 +3,332 @@
 [![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/indexes.md%26commit_hash%3D438bcb89ea692f219b30f3a3ba107888b23eae98)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/indexes.md&commit_hash=438bcb89ea692f219b30f3a3ba107888b23eae98)
 
 有關不在此索引中的 API，請參閱 [此處](../API/index.md)。
-有關術語，請參見 [此處](../dev_guide/terms.md)。
+
+有關術語，請參見 [此處](../terms.md)。
 
 ## 符號
 
-* !
-  * !-type → [可變性](./type/mut.md)
-* [&#35;](./00_basic.md/#comment)
-* $
+* ! → [side&nbsp;effect](./07_side_effect.md)
+  * !-type → [mutable&nbsp;type](./type/18_mut.md)
+* ? → [error&nbsp;handling](./30_error_handling.md)
+* &#35; → [Str](./00_basic.md/#comment)
+* $ → [shared](./type/advanced/shared.md)
 * %
 * &
   * &&
-* &prime; (single quote)
-* &lpar;&rpar;
+* [&prime;&nbsp;(single&nbsp;quote)](./20_naming_rule.md)
+* [&quot;&nbsp;(double&nbsp;quote)](./01_literal.md)
+* &lpar;&rpar; → [Tuple](./11_tuple.md)
 * &ast;
-  * [*-less multiplication](./01_literal.md/#less-multiplication)
-* &plus; (前置)
+  * &ast; → [*-less&nbsp;multiplication](./01_literal.md/#less-multiplication)
+* &plus; (前置) → [operator](./06_operator.md)
   * &plus;_ → &plus; (前置)
-* &plus; (中置)
+* &plus; (中置) → [operator](./06_operator.md)
+* &plus; (中置) → [Trait](./type/03_trait.md)
 * ,
 * &minus; (前置)
   * &minus;_ → &minus; (前置)
-* &minus; (中置)
-  * &minus;>
-* . → [可見性]
+* &minus; (中置) → [operator](./06_operator.md)
+* &minus; (中置) → [Trait](./type/03_trait.md)
+  * &minus;> → [anonymous&nbsp;function](./21_lambda.md)
+* . → [Visibility](./19_visibility.md)
+  * [...&nbsp;assignment](./28_spread_syntax.md)
+  * [...&nbsp;Extract&nbsp;assignment](./28_spread_syntax.md)
+  * [...&nbsp;function](./04_function.md)
 * /
 * :
-  * :: → [可見性]
+  * : → [Colon&nbsp;application&nbsp;style](./04_function.md)
+  * : → [Declaration](./03_declaration.md.md)
+  * : → [Keyword&nbsp;Arguments](./04_function.md)
+  * :: → [visibility](./19_visibility.md)
+  * := → [default&nbsp;parameters](./04_function.md)
 * ;
 * &lt;
-  * &lt;:
+  * &lt;: → [Subtype&nbsp;specification](./type/02_basic.md)
   * &lt;&lt;
   * &lt;=
-* =
+* = → [Variable](./19_visibility.md)
   * ==
-  * =>
+  * => → [procedure](./08_procedure.md)
 * &gt;
   * &gt;&gt;
   * &gt;=
-* ?
-* @
-* []
-* \
+* @ → [decorator](./29_decorator.md)
+* [] → [Array](./10_array.md)
+* \ → [Indention](./00_basic.md)
+* \ → [Str](./01_literal.md)
 * ^
   * ^^
-* _
+* _ → [Type&nbsp;erasure](./type/advanced/erasure.md)
   * &#95;+&#95; → &plus; (infix)
   * &#95;-&#95; → &minus; (infix)
-*``
+* [``&nbsp;(back&nbsp;quote)](./22_subroutine.md)
 * {}
-  * {} type
+  * [{} type](./type/01_type_system.md)
 * {:}
-* {=}
-  * {=} type
+* {=} → [Type&nbsp;System](./type/01_type_system.md)
+  * [{=}&nbsp;type](./13_record.md)
 * |
-  * ||
+  * || → [Type variable list](./type/advanced/)
 * ~
 
-## 字母
+## アルファベット
 
 ### A
 
-* algebraic&nbsp;type
-* And
-* and
-* assert
-* attribute
+* [Add]
+* [alias](type/02_basic.md)
+* [Aliasing](./type/02_basic.md)
+* [All&nbsp;symmetric&nbsp;types](./type/15_quantified.md)
+* [algebraic&nbsp;type](./type/13_algebraic.md)
+* [And]
+* [and]
+* [anonymous&nbsp;function](./21_lambda.md)
+* [Anonymous&nbsp;polycorrelation&nbsp;coefficient](./21_lambda.md)
+* anonymous type → [Type&nbsp;System](./type/01_type_system.md)
+* [Array](./10_array.md)
+* [assert]
+* [Attach](./29_decorator.md)
+* [attribute](type/09_attributive.md)
+* [Attribute&nbsp;definitions](./type/02_basic.md)
+* [Attribute&nbsp;Type](./type/09_attributive.md)
 
 ### B
 
-* Base
-* Bool
+* [Bool, Boolean](./01_literal.md)
+* [Boolean&nbsp;Object](./01_literal.md)
+* [borrow](./18_ownership.md)
 
 ### C
 
-* Class
+* [Cast](./type/17_type_casting.md)
+* [Comments](./00_basic.md)
+* [Complex&nbsp;Object](./01_literal.md)
+* [Compile-time&nbsp;functions](./04_function.md)
+* [circular&nbsp;references](./18_ownership.md)
+* [Class](./type/04_class.md)
+* [Class&nbsp;Relationship](./type/04_class.md)
+* [Class&nbsp;upcasting](./type/16_subtyping.md)
+* [Colon&nbsp;application&nbsp;style](./04_function.md)
+* [Closure](./23_closure.md)
+* [Compound Literals](./01_literal.md)
+* [Complement](./type/13_algebraic.md)
+* [Comprehension](./27_comprehension.md)
+* [constant](./17_mutability.md)
+* [Constants](./02_name.md)
+* [Context](./30_error_handling.md)
 
 ### D
 
+* [Data&nbsp;type](./type/01_type_system.md)
+* [Declaration](./03_declaration.md)
+* [decorator](./29_decorator.md)
+* [Default&nbsp;parameters](./04_function.md)
+* [Del](./02_name.md)
+* [Dependent&nbsp;Type](./type/14_dependent.md)
+* [Deconstructing&nbsp;a&nbsp;record](13_record.md)
 * Deprecated
+* [Dict](./12_dict.md)
+* [Diff](./type/13_algebraic.md)
+* [Difference&nbsp;from&nbsp;Data&nbsp;Class](./type/04_class.md)
+* [Difference&nbsp;from&nbsp;structural&nbsp;types](type/04_class.md)
 * distinct
+* [Downcasting](./type/17_type_casting.md)
 
 ### E
 
-* enum&nbsp;type
-* Eq
-* Erg
+* [Empty&nbsp;Record](./13_record.md)
+* [Enum&nbsp;Class](./type/04_class.md)
+* [Enum&nbsp;type](./type/11_enum.md)
+* [Enumerated,&nbsp;Interval&nbsp;and&nbsp;Refinement&nbsp;Types](./type/12_refinement.md)
+* [error&nbsp;handling](./30_error_handling.md)
+* [Existential&nbsp;type](./type/advanced/existential.md)
+* [Exponential&nbsp;Literal](./01_literal.md)
+* [Extract&nbsp;assignment](./28_spread_syntax.md)
 
 ### F
 
-* for
+* False → [Boolean Object](./01_literal.md)
+* [Float&sbsp;Object](./01_literal.md)
+* [for](./05_builtin_funcs.md)
+* [For-All&nbsp;Patch](./type/07_patch.md)
+* [freeze](./18_ownership.md)
+* [Function](./04_function.md)
+* [Function&nbsp;definition&nbsp;with&nbsp;multiple patterns](./04_function.md)
 
 ### G
+
+* [GADTs(Generalized&nbsp;Algebraic&nbsp;Data&nbsp;Types)](./type/advanced/GADTs.md)
+* [Generator](./34_generator.md)
+* [Glue&nbsp;Patch](./type/07_patch.md)
 
 ### H
 
 ### I
 
-* if
-* import
-* in
-* Int
+* [id](./09_builtin_procs.md)
+* [if](./05_builtin_funcs.md)
+* [import](./33_package_system.md)
+* [impl](./29_decorator.md)
+* [in]
+* [Indention](./00_basic.md)
+* [Instant&nbsp;Block](./13_record.md)
+* [Instance&nbsp;and&nbsp;class&nbsp;attributes](./type/04_class.md)
+* [Implementing&nbsp;and&nbsp;resolving&nbsp;duplicate&nbsp;traits&nbsp;in&nbsp;the&nbsp;API](type/03_trait.md)
+* [inheritable](./29_decorator.md)
+* [inheritance](./type/05_inheritance.md)
+* [Inheritance&nbsp;of&nbsp;Enumerated&nbsp;Classes](./type/05_inheritance.md)
+* [Int](./01_literal.md)
+* [Integration&nbsp;with&nbsp;Python](./32_integration_with_Python.md)
+* [Interval&nbsp;Type](./type/10_interval.md)
+* [Intersection](./type/13_algebraic.md)
+* [Iterator](./16_iterator.md)
 
 ### J
 
 ### K
 
+* [Keyword&nbsp;arguments](./04_function.md)
+* [Kind](./type/advanced/kind.md)
+
 ### L
 
-* let-polymorphism → [rank 1 polymorphism]
-* log
+* lambda → [anonymous&nbsp;function](./21_lambda.md)
+* let-polymorphism → [rank&nbsp;1&nbsp;polymorphism]
+* [Literal&nbsp;Identifiers](./20_naming_rule.md)
+* log → [side&nbsp;effect](./07_side_effect.md)
 
 ### M
 
-* match
+* [match]
+* [Marker&nbsp;Trait](./type/advanced/marker_trait.md)
+* [Method](./07_side_effect.md)
+* Modifier → [decorator](./29_decorator.md)
+* [module](./24_module.md)
+* [Multiple&nbsp;Inheritance](type/05_inheritance.md)
+* [Multi-layer&nbsp;(multi-level)&nbsp;Inheritance](type/05_inheritance.md)
+* [Mutable&nbsp;Type](./type/18_mut.md)
+* [Mutable&nbsp;Structure&nbsp;Type](./type/advanced/mut_struct.md)
+* [Mutability](./17_mutability.md)
 
 ### N
 
-* Nat
-* Never
-* None
-* None
-* Not
-* not
+* [Nat](./01_literal.md)
+* [Never]
+* [New&nbsp;type](./type/advanced/newtype.md)
+* [Heterogeneous&nbsp;Dict](./12_dict.md)
+* None → [None&nbsp;Object]
+* [None&nbsp;Object]
+* Nominal&nbsp;Subtyping → [Class](./type/04_class.md)
+* [Not]
+* [not]
 
 ### O
 
-* Option
-* Or
-* or
-* Ord
+* [Object](./25_object_system.md)
+* [Option]
+* [Or]
+* [or]
+* [Ord]
+* [ownership&nbsp;system](./18_ownership.md)
+* [Overloading](./type/advanced/overloading.md)
+* [Overriding](./type/05_inheritance.md)
+* [Override&nbsp;in&nbsp;Trait](./type/03_trait.md)
 
 ### P
 
-* panic
-* [print!](./../API/procs.md#print)
-* Python
+* [Panic](./30_error_handling.md)
+* [Patch](./type/07_patch.md)
+* [Pattern&nbsp;match](./26_pattern_matching.md)
+* [Phantom&nbsp;class](./type/advanced/phantom.md)
+* [pipeline&nbsp;operator](./31_pipeline.md)
+* [Predicate](./type/19_bound.md)
+* [print!]
+* [Procedures](./08_procedure.md)
+* [Projection&nbsp;Type](./type/advanced/projection.md)
+* Python → [Integration&nbsp;with&nbsp;Python](./32_integration_with_Python.md)
 
 ### Q
 
+* [Quantified&nbsp;Type](./type/15_quantified.md)
+* [Quantified&nbsp;Dependent&nbsp;Type](./type/advanced/quantified_dependent.md)
+* [Quantified&nbsp;Types&nbsp;and&nbsp;Dependent&nbsp;Types](./type/15_quantified.md)
+
 ### R
 
-* ref
-* ref!
-* Result
+* [Range&nbsp;Object](./01_literal.md)
+* [ref]
+* [ref!]
+* [Record](./13_record.md)
+* [Record&nbsp;Type&nbsp;Composite](./type/09_attributive.mda12_refinement.md)
+* [Recursive&nbsp;functions](./04_function.md)
+* [Refinement&nbsp;pattern](./type/12_refinement.md)
+* [Refinement&nbsp;Type](./type/12_refinement.md)
+* [replication](./18_ownership.md)
+* [Replacing&nbsp;Traits](./type/05_inheritance.md)
+* Result → [error&nbsp;handling](./30_error_handling.md)
+* [Rewriting&nbsp;Inherited&nbsp;Attributes](./type/05_inheritance.md)
 * rootobj
 
 ### S
 
+* [Script](./00_basic.md)
+* [Selecting&nbsp;Patches](./type/07_patch.md)
 * self
-* [Self](./type/special.md)
+* [Self](./type/advanced/special.md)
+* [Shared&nbsp;Reference](./type/advanced/shared.md)
 * [side-effect](./07_side_effect.md)
-* Str
+* [Smart&nbsp;Cast](./type/12_refinement.md)
+* [Spread&nbsp;assignment](./28_spread_syntax.md)
+* [special&nbsp;type&nbsp;variables](./type/advanced/special.md)
+* [Stack&nbsp;trace](30_error_handling.md)
+* [Structure&nbsp;type](./type/01_type_system.md)
+* [Structural&nbsp;Patch](./type/07_patch.md)
+* [Structural&nbsp;Trait](./type/03_trait.md)
+* [Structural&nbsp;Subtyping](./type/01_type_system.md)
+* [Structural&nbsp;types&nbsp;and&nbsp;class&nbsp;type&nbsp;relationships](./type/16_subtyping.md)
+* [Str](./01_literal.md)
+* [Subtyping](./type/16_subtyping.md)
+* [Subtyping&nbsp;of&nbsp;subroutines](./type/16_subtyping.md)
+* [Subtype&nbsp;specification](./type/02_basic.md)
+* [Subtyping&nbsp;of&nbsp;Polymorphic&nbsp;Function Types](./type/15_quantified.md)
+* [Subroutine&nbsp;Signatures](./22_subroutine.md)
 
 ### T
 
-* Traits
-* True
-* Type
-* type
+* [Test](./29_decorator.md)
+* [Traits](./type/03_trait.md)
+* [Trait&nbsp;inclusion](./type/03_trait.md)
+* True → [Boolean&nbsp;Object](./01_literal.md)
+* [True&nbsp;Algebraic&nbsp;type](./type/13_algebraic.md)
+* [Type]
+* [type](./15_type.md)
+* [Type&nbsp;arguments&nbsp;in&nbsp;method&nbsp;definitions](./type/15_quantified.md)
+* [Type&nbsp;Bound](./type/19_bound.md)
+* [Type&nbsp;Definitions](./type/01_type_system.md)
+* [Type&nbsp;erasure](./type/advanced/erasure.md)
+* [Type&nbsp;Inference&nbsp;System](./type/01_type_system.md)
+* [Type&nbsp;specification](./type/02_basic.md)
+* [Type&nbsp;System](./type/01_type_system.md)
+* [Type&nbsp;Widening](./type/advanced/widening.md)
+* [Tuple](./11_tuple.md)
 
 ### U
 
+* [union](type/13_algebraic.md)
+* [Unit](./11_tuple.md)
+* [Upcasting](type/17_type_casting.md)
+* [Usage&nbsp;of&nbsp;Inheritance](./type/05_inheritance.md)
+
 ### V
+
+* [Value&nbsp;Type](./type/08_value.md)
+* [Variable](./02_name.md)
+* [variable-length&nbsp;arguments](./04_function.md)
 
 ### W
 
-* while!
+* [while]
 
 ### X
 


### PR DESCRIPTION
Related #142.

In the file indexes.md, added links corresponding to the title and subtitle.

Some links are not linked to any subheading.

I'll leave this one for a few days.

Then review it again and copy it to other Ja, zh_CN and zh_TW.

@mtshiba
