### PR TITLE
Python methods declarations

### DIFF
--- a/compiler/erg_compiler/codegen.rs
+++ b/compiler/erg_compiler/codegen.rs
@@ -1455,7 +1455,6 @@ impl CodeGenerator {
         log!(info "entered {}", fn_name!());
         let class = obj.ref_t().name(); // これは必ずmethodのあるクラスになっている
         let uniq_obj_name = obj.__name__().map(Str::rc);
-        log!("{class} {method_name}");
         if &method_name.inspect()[..] == "update!" {
             return self.emit_call_update(obj, args);
         } else if is_fake_method(&class, method_name.inspect()) {

--- a/compiler/erg_compiler/context/register.rs
+++ b/compiler/erg_compiler/context/register.rs
@@ -628,7 +628,7 @@ impl Context {
         }
     }
 
-    fn register_gen_type(&mut self, ident: &Identifier, gen: GenTypeObj) {
+    pub(crate) fn register_gen_type(&mut self, ident: &Identifier, gen: GenTypeObj) {
         match gen.kind {
             TypeKind::Class => {
                 if gen.t.is_monomorphic() {

--- a/compiler/erg_parser/parse.rs
+++ b/compiler/erg_parser/parse.rs
@@ -1765,6 +1765,8 @@ impl Parser {
                         let err = self.skip_and_throw_syntax_err(caused_by!());
                         self.errs.push(err);
                         return Err(());
+                    } else if self.cur_is(RParen) {
+                        break;
                     }
                     match self.try_reduce_arg(false).map_err(|_| self.stack_dec())? {
                         PosOrKwArg::Pos(arg) => match arg.expr {

--- a/compiler/erg_type/deserialize.rs
+++ b/compiler/erg_type/deserialize.rs
@@ -124,9 +124,18 @@ impl Deserializer {
             eprintln!("{:?} is not a filename", cfg.input);
             process::exit(1);
         };
-        let codeobj = CodeObj::from_pyc(&filename)
-            .unwrap_or_else(|_| panic!("failed to deserialize {}", filename.to_string_lossy()));
-        println!("{}", codeobj.code_info());
+        match CodeObj::from_pyc(&filename) {
+            Ok(codeobj) => {
+                println!("{}", codeobj.code_info());
+            }
+            Err(e) => {
+                eprintln!(
+                    "failed to deserialize {}: {}",
+                    filename.to_string_lossy(),
+                    e.desc
+                )
+            }
+        }
     }
 
     fn get_cached_str(&mut self, s: &str) -> ValueObj {

--- a/examples/declare.d.er
+++ b/examples/declare.d.er
@@ -1,2 +1,6 @@
 .x: Int
 .f: Int -> Int
+
+.C: ClassType
+.C.__call__: Int -> .C
+.C.f: Int -> Int

--- a/examples/declare.d.er
+++ b/examples/declare.d.er
@@ -2,5 +2,6 @@
 .f: Int -> Int
 
 .C: ClassType
-.C.__call__: Int -> .C
-.C.f: Int -> Int
+# or .C.__call__: Int -> .C
+.C.__call__: (x: Int,) -> .C
+.C.f: (self: .C, y: Int) -> Int

--- a/examples/declare.py
+++ b/examples/declare.py
@@ -1,2 +1,8 @@
 x = 0
 def f(x: int) -> int: return x + 1
+
+class C:
+    def __init__(self, x: int) -> None:
+        self.x = x
+    def f(self, y: int) -> int:
+        return self.x + y

--- a/examples/use_py.er
+++ b/examples/use_py.er
@@ -1,3 +1,5 @@
 declare = pyimport "declare"
 
 print! declare.f(declare.x + 1)
+c = declare.C.__call__ 1
+print! c.f(1)


### PR DESCRIPTION
Python methods can now be declared from `d.er`.
