### PR TITLE
Possible to localized to help commands

### DIFF
--- a/compiler/erg_common/config.rs
+++ b/compiler/erg_common/config.rs
@@ -201,9 +201,10 @@ impl ErgConfig {
         let mut cfg = Self::default();
         // ループ内でnextするのでforにしないこと
         while let Some(arg) = args.next() {
+            let next_arg = args.next();
             match &arg[..] {
-                "-c" => {
-                    cfg.input = Input::Str(args.next().unwrap());
+                "-c" if next_arg.is_some() => {
+                    cfg.input = Input::Str(next_arg.unwrap());
                 }
                 "--dump-as-pyc" => {
                     cfg.dump_as_pyc = true;
@@ -213,32 +214,43 @@ impl ErgConfig {
                     println!("{}", CMD_HELP);
                     process::exit(0);
                 }
-                "-m" => {
-                    cfg.module = Box::leak(args.next().unwrap().into_boxed_str());
+                "-m" if next_arg.is_some() => {
+                    cfg.module = Box::leak(next_arg.unwrap().into_boxed_str());
                 }
-                "--mode" => {
-                    cfg.mode = Box::leak(args.next().unwrap().into_boxed_str());
+                "--mode" if next_arg.is_some() => {
+                    let mode = next_arg.unwrap();
+                    if let "-?" | "-h" | "--help" = &mode[..] {
+                        println!("{}", MODE_HELP);
+                        process::exit(0);
+                    }
+                    cfg.mode = Box::leak(mode.into_boxed_str());
                 }
-                "--ps1" => {
-                    cfg.ps1 = Box::leak(args.next().unwrap().into_boxed_str());
+                "--ps1" if next_arg.is_some() => {
+                    cfg.ps1 = Box::leak(next_arg.unwrap().into_boxed_str());
                 }
-                "--ps2" => {
-                    cfg.ps2 = Box::leak(args.next().unwrap().into_boxed_str());
+                "--ps2" if next_arg.is_some() => {
+                    cfg.ps2 = Box::leak(next_arg.unwrap().into_boxed_str());
                 }
-                "-o" | "--opt-level" | "--optimization-level" => {
-                    cfg.opt_level = args.next().unwrap().parse::<u8>().unwrap();
+                "-o" | "--opt-level" | "--optimization-level" if next_arg.is_some() => {
+                    cfg.opt_level = next_arg.unwrap().parse::<u8>().unwrap();
                 }
-                "-p" | "--py-ver" | "--python-version" => {
-                    cfg.python_ver = Some(args.next().unwrap().parse::<u32>().unwrap());
+                "-p" | "--py-ver" | "--python-version" if next_arg.is_some() => {
+                    if let Ok(ver) = next_arg.unwrap().parse::<u32>() {
+                        cfg.python_ver = Some(ver)
+                    }
                 }
-                "--py-server-timeout" => {
-                    cfg.py_server_timeout = args.next().unwrap().parse::<u64>().unwrap();
+                "--py-server-timeout" if next_arg.is_some() => {
+                    if let Ok(time) = next_arg.unwrap().parse::<u64>() {
+                        cfg.py_server_timeout = time;
+                    }
                 }
                 "--quiet-startup" => {
                     cfg.quiet_startup = true;
                 }
-                "--verbose" => {
-                    cfg.verbose = args.next().unwrap().parse::<u8>().unwrap();
+                "--verbose" if next_arg.is_some() => {
+                    if let Ok(vr) = next_arg.unwrap().parse::<u8>() {
+                        cfg.verbose = vr;
+                    }
                 }
                 "-V" | "--version" => {
                     println!("Erg {}", env!("CARGO_PKG_VERSION"));

--- a/compiler/erg_common/config.rs
+++ b/compiler/erg_common/config.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::str::FromStr;
 
-use crate::help_messages::{CMD_HELP, MODE_HELP};
+use crate::help_messages::{command_message, mode_message};
 use crate::stdin::GLOBAL_STDIN;
 use crate::{power_assert, read_file};
 
@@ -211,7 +211,7 @@ impl ErgConfig {
                 }
                 "-?" | "-h" | "--help" => {
                     // TODO:
-                    println!("{}", CMD_HELP);
+                    println!("{}", command_message());
                     process::exit(0);
                 }
                 "-m" if next_arg.is_some() => {
@@ -220,7 +220,7 @@ impl ErgConfig {
                 "--mode" if next_arg.is_some() => {
                     let mode = next_arg.unwrap();
                     if let "-?" | "-h" | "--help" = &mode[..] {
-                        println!("{}", MODE_HELP);
+                        println!("{}", mode_message());
                         process::exit(0);
                     }
                     cfg.mode = Box::leak(mode.into_boxed_str());

--- a/compiler/erg_common/config.rs
+++ b/compiler/erg_common/config.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::str::FromStr;
 
+use crate::help_messages::{CMD_HELP, MODE_HELP};
 use crate::stdin::GLOBAL_STDIN;
 use crate::{power_assert, read_file};
 
@@ -208,21 +209,8 @@ impl ErgConfig {
                     cfg.dump_as_pyc = true;
                 }
                 "-?" | "-h" | "--help" => {
-                    println!("erg [option] ... [-c cmd | -m mod | file | -] [arg] ...");
-                    println!("-c cmd : program passed in as string");
-                    println!("-m mod : module to be executed");
-                    println!("-?/-h  : show this help");
-                    println!("--dump-as-pyc: dump as .pyc file");
-                    println!("--mode lex|parse|compile|exec: execution mode");
-                    println!("--opt-level/-o 0|1|2|3: optimization level");
-                    println!("--python-version/-p (uint 32 number): Python version");
-                    println!(
-                        "--py-server-timeout (uint 64 number): timeout for the Python REPL server"
-                    );
-                    println!("--verbose 0|1|2: verbosity level");
-                    println!("--version/-V: show version");
-                    println!("file : program read from script file");
                     // TODO:
+                    println!("{}", CMD_HELP);
                     process::exit(0);
                 }
                 "-m" => {

--- a/compiler/erg_common/help_messages.rs
+++ b/compiler/erg_common/help_messages.rs
@@ -40,9 +40,9 @@ OPTIONS
     --version/-V                         显示版本
     --verbose 0|1|2                      指定细致程度
     --opt-level/-o 0|1|2|3               指定优化级别
-    --python-version/-p (uint 32 number) Python版本
-    --py-server-timeout (uint 64 number) Python REPL服务器超时
-    --dump-as-pyc                        转储为.pyc文件
+    --python-version/-p (uint 32 number) Python 版本
+    --py-server-timeout (uint 64 number) Python REPL 服务器超时
+    --dump-as-pyc                        转储为 .pyc 文件
     --mode lex|parse|compile|exec        执行模式
     
 SUBCOMMAND
@@ -137,31 +137,31 @@ USAGE:
     erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
 
 lex
-    从 <filename>.er, REPL等接受输入, 并标记文本
+    从 <filename>.er, REPL 等接受输入, 并标记文本
     以TokenStream形式返回分析结果
 
 parse
-    执行lex, 获取TokenStream, 并解析语法
+    执行 lex, 获取 TokenStream, 并解析语法
     将多模式定义语句的语法糖按匹配转换并返回ast(抽象语法树)
 
 lower
-    执行parse以获取ast
-    解析名称、检查类型和推断, 并返回ast
+    执行 parse 以获取 ast
+    解析名称、检查类型和推断, 并返回 ast
 
 check
-    执行lower并获取ast
-    检查副作用、所有权并返回ast
+    执行 lower 并获取 ast
+    检查副作用、所有权并返回 ast
 
 compile
-    运行check以获取检查完成的ast
-    编译ast并返回<文件名>.pyc
+    运行 check 以获取检查完成的 ast
+    编译 ast 并返回 <文件名>.pyc
 
 exec
-    运行check以获取检查完成的ast
-    在执行<filename>.pyc后删除<文件名>.pyc
+    运行 check 以获取检查完成的 ast
+    在执行 <filename>.pyc 后删除 <文件名>.pyc
 
 read
-    反序列化<文件名>.pyc和dump",
+    反序列化<文件名> .pyc 和 dump",
 
     "traditional_chinese" =>
     "\
@@ -169,31 +169,31 @@ USAGE:
         erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
     
 lex
-    從<檔名>.er, REPL等接受輸入, 並標記文字
-    以TokenStream形式返回分析結果
+    從 <檔名>.er, REPL 等接受輸入, 並標記文字
+    以 TokenStream 形式返回分析結果
     
 parse
-    執行lex, 獲取TokenStream, 並解析語法
-    將多模式定義語句的語法糖按匹配轉換並返回ast(抽象語法樹)
+    執行 lex, 獲取 TokenStream, 並解析語法
+    將多模式定義語句的語法糖按匹配轉換並返回 ast(抽象語法樹)
     
 lower
-    執行parse以獲取ast
-    解析名稱、檢查類型和推斷, 並返回ast
+    執行 parse 以獲取 ast
+    解析名稱、檢查類型和推斷, 並返回 ast
     
 check
-    執行lower並獲取ast
-    檢查副作用、所有權並返回ast
+    執行 lower 並獲取 ast
+    檢查副作用、所有權並返回 ast
     
 compile
-    運行check以獲取檢查完成的ast
-    編譯ast並返回<檔名>.pyc
+    運行 check 以獲取檢查完成的 ast
+    編譯 ast 並返回 <檔名>.pyc
     
 exec
     運行check以獲取檢查完成的ast
     在執行<檔名>.pyc後删除<檔名>.pyc
     
 read
-    反序列化<檔名>.pyc和dump",
+    反序列化 <檔名>.pyc 和 dump",
 
     "english" =>
     "\

--- a/compiler/erg_common/help_messages.rs
+++ b/compiler/erg_common/help_messages.rs
@@ -10,7 +10,7 @@ USAGE:
 
 ARGS:
     <script> スクリプトファイルからプログラムを読み込む
-             <script>に渡す引数を入力する
+            <script>に渡す引数を入力する
 
 OPTIONS
     --help/-?/-h                         このhelpを表示
@@ -27,26 +27,26 @@ SUBCOMMAND
     -m mod : モジュールを実行",
 
     "simplified_chinese" =>
-        "\
+    "\
 USAGE:
     erg [OPTIONS] [SUBCOMMAND] [ARGS]...
-
+    
 ARGS:
-    <script> 從腳本文件中讀取的程序
-             參數也可以指定傳遞給 <script>
-
+    <script> 从脚本文件读取程序
+            参数也可以指定要传递给 <script>
+    
 OPTIONS
-    --help/-?/-h                         显示此帮助
+    --help/-?/-h                         显示帮助
     --version/-V                         显示版本
-    --verbose 0|1|2                      详细程度
-    --opt-level/-o 0|1|2|3               优化级别
+    --verbose 0|1|2                      指定细致程度
+    --opt-level/-o 0|1|2|3               指定优化级别
     --python-version/-p (uint 32 number) Python版本
     --py-server-timeout (uint 64 number) Python REPL服务器超时
-    --dump-as-pyc                        转储为 .pyc 文件
+    --dump-as-pyc                        转储为.pyc文件
     --mode lex|parse|compile|exec        执行模式
-
+    
 SUBCOMMAND
-    -c cmd : 作为字符串传入的程序
+    -c cmd : 作为字符串传入程序
     -m mod : 要执行的模块",
 
     "traditional_chinese" =>
@@ -55,21 +55,21 @@ USAGE:
     erg [OPTIONS] [SUBCOMMAND] [ARGS]...
 
 ARGS:
-    <script> 从脚本文件中读取的程序
-             参数也可以指定传递给 <script>
+    <script> 從腳本檔案讀取程式
+            參數也可以指定要傳遞給 <script>
 
 OPTIONS
-    --help/-?/-h                         顯示此幫助
+    --help/-?/-h                         顯示幫助
     --version/-V                         顯示版本
-    --verbose 0|1|2                      詳細程度
-    --opt-level/-o 0|1|2|3               優化級別
+    --verbose 0|1|2                      指定細緻程度
+    --opt-level/-o 0|1|2|3               指定優化級別
     --python-version/-p (uint 32 number) Python 版本
     --py-server-timeout (uint 64 number) Python REPL 服務器超時
     --dump-as-pyc                        轉儲為 .pyc 文件
     --mode lex|parse|compile|exec        執行模式
 
 SUBCOMMAND
-    -c cmd : 作為字符串傳入的程序
+    -c cmd : 作為字串傳入程式
     -m mod : 要執行的模塊",
 
     "english" =>
@@ -79,7 +79,7 @@ USAGE:
 
 ARGS:
     <script> program read from script file
-             Arguments can also be specified to be passed to the <script>
+            Arguments can also be specified to be passed to the <script>
 
 OPTIONS
     --help/-?/-h                         show this help
@@ -131,72 +131,72 @@ exec
 read
     <filename>.pycをデシリアライズしダンプ",
 
-    "traditional_chinese" =>
-        "\
-USAGE:
-    erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
-
-lex
-    从 <filename>.er、REPL 等接收输入，并标记文本
-    以 TokenStream 形式返回分析结果
-
-parse
-    执行lex，获取TokenStream，解析语法
-    对多个模式定义语句进行脱糖，通过匹配转换并返回 ast（抽象语法树）
-
-lower
-    执行 parse 得到 ast
-    解析名称，检查类型和推断，并返回 ast
-
-check
-    执行lower并get ast
-    检查副作用、所有权和回报
-
-compile
-    運行檢查以檢查 ast
-    編譯 ast 並返回 <filename>.pyc
-
-exec
-    执行检查以检查 ast
-    执行 <filename>.pyc 后删除 <filename>.pyc
-
-read
-    反序列化 <filename>.pyc 并转储",
-
     "simplified_chinese" =>
-        "\
+    "\
 USAGE:
     erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
 
 lex
-    從 <filename>.er、REPL 等接收輸入，並標記文本
-    以 TokenStream 形式返回分析結果
+    从 <filename>.er, REPL等接受输入, 并标记文本
+    以TokenStream形式返回分析结果
 
 parse
-    執行lex，獲取TokenStream，解析語法
-    對多個模式定義語句進行脫糖，通過匹配轉換並返回 ast（抽象語法樹）
+    执行lex, 获取TokenStream, 并解析语法
+    将多模式定义语句的语法糖按匹配转换并返回ast(抽象语法树)
 
 lower
-    執行 parse 得到 ast
-    解析名稱，檢查類型和推斷，並返回 ast
+    执行parse以获取ast
+    解析名称、检查类型和推断, 并返回ast
 
 check
-    執行lower並get ast
-    檢查副作用、所有權和回報
+    执行lower并获取ast
+    检查副作用、所有权并返回ast
 
 compile
-    运行检查以检查 ast
-    编译 ast 并返回 <filename>.pyc
+    运行check以获取检查完成的ast
+    编译ast并返回<文件名>.pyc
 
 exec
-    執行檢查以檢查 ast
-    執行 <filename>.pyc 後刪除 <filename>.pyc
+    运行check以获取检查完成的ast
+    在执行<filename>.pyc后删除<文件名>.pyc
 
 read
-    反序列化 <filename>.pyc 並轉儲",
+    反序列化<文件名>.pyc和dump",
+
+    "traditional_chinese" =>
+    "\
+USAGE:
+        erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
+    
+lex
+    從<檔名>.er, REPL等接受輸入, 並標記文字
+    以TokenStream形式返回分析結果
+    
+parse
+    執行lex, 獲取TokenStream, 並解析語法
+    將多模式定義語句的語法糖按匹配轉換並返回ast(抽象語法樹)
+    
+lower
+    執行parse以獲取ast
+    解析名稱、檢查類型和推斷, 並返回ast
+    
+check
+    執行lower並獲取ast
+    檢查副作用、所有權並返回ast
+    
+compile
+    運行check以獲取檢查完成的ast
+    編譯ast並返回<檔名>.pyc
+    
+exec
+    運行check以獲取檢查完成的ast
+    在執行<檔名>.pyc後删除<檔名>.pyc
+    
+read
+    反序列化<檔名>.pyc和dump",
 
     "english" =>
-        "\
+    "\
 USAGE:
     erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
 

--- a/compiler/erg_common/help_messages.rs
+++ b/compiler/erg_common/help_messages.rs
@@ -176,12 +176,12 @@ parse
     將多模式定義語句的語法糖按匹配轉換並返回 AST(抽象語法樹)
 
 lower
-    執行 parse 以獲取 AST
+    執行 parse
     解析名稱、檢查類型和推斷, 並返回 HIR(高級中間表示)
 
 check
-    執行 lower 並獲取 AST
-    檢查副作用、所有權並返回 AST
+    執行 lower
+    檢查副作用、所有權並返回 HIR
 
 compile
     運行 check 以獲取檢查完成的 AST

--- a/compiler/erg_common/help_messages.rs
+++ b/compiler/erg_common/help_messages.rs
@@ -144,12 +144,12 @@ parse
     将多模式定义语句的语法糖按匹配转换并返回AST(抽象语法树)
 
 lower
-    执行 parse 以获取 AST
-    解析名称、检查类型和推断, 并返回 AST
+    执行 parse
+    解析名称、检查类型和推断, 并返回HIR(高级中间表示)
 
 check
-    执行 lower 并获取 AST
-    检查副作用、所有权并返回 AST
+    执行 lower
+    检查副作用、所有权并返回HIR
 
 compile
     运行 check 以获取检查完成的 AST
@@ -212,11 +212,11 @@ lower
 
 check
     Execute lowering
-    Check side-effects, ownership and return AST
+    Check side-effects, ownership and return HIR
 
 compile
     Execute check
-    Compile AST and return <filename>.pyc
+    Compile HIR and return <filename>.pyc
 
 exec
     Execute compiling & executing <filename>.pyc

--- a/compiler/erg_common/help_messages.rs
+++ b/compiler/erg_common/help_messages.rs
@@ -137,19 +137,19 @@ USAGE:
 
 lex
     从 <filename>.er, REPL 等接受输入, 并标记文本
-    以TokenStream形式返回分析结果
+    以 TokenStream 形式返回分析结果
 
 parse
     执行 lex, 获取 TokenStream, 并解析语法
-    将多模式定义语句的语法糖按匹配转换并返回AST(抽象语法树)
+    将多模式定义语句的语法糖按匹配转换并返回 AST(抽象语法树)
 
 lower
     执行 parse
-    解析名称、检查类型和推断, 并返回HIR(高级中间表示)
+    解析名称、检查类型和推断, 并返回 HIR(高级中间表示)
 
 check
     执行 lower
-    检查副作用、所有权并返回HIR
+    检查副作用、所有权并返回 HIR
 
 compile
     运行 check 以获取检查完成的 AST
@@ -157,10 +157,10 @@ compile
 
 exec
     运行 check 以获取检查完成的 AST
-    在执行 <filename>.pyc 后删除 <文件名>.pyc
+    在执行 <文件名>.pyc 后删除 <文件名>.pyc
 
 read
-    反序列化<文件名> .pyc 和 dump",
+    反序列化 <文件名>.pyc 和 dump",
 
     "traditional_chinese" =>
     "\
@@ -176,8 +176,8 @@ parse
     將多模式定義語句的語法糖按匹配轉換並返回 AST(抽象語法樹)
 
 lower
-    執行 parse 以獲取AST
-    解析名稱、檢查類型和推斷, 並返回HIR
+    執行 parse 以獲取 AST
+    解析名稱、檢查類型和推斷, 並返回 HIR(高級中間表示)
 
 check
     執行 lower 並獲取 AST
@@ -188,8 +188,8 @@ compile
     編譯 AST 並返回 <檔名>.pyc
 
 exec
-    運行check以獲取檢查完成的AST
-    在執行<檔名>.pyc後删除<檔名>.pyc
+    運行check以獲取檢查完成的 AST
+    在執行 <檔名>.pyc 後删除 <檔名>.pyc
 
 read
     反序列化 <檔名>.pyc 和 dump",

--- a/compiler/erg_common/help_messages.rs
+++ b/compiler/erg_common/help_messages.rs
@@ -200,28 +200,29 @@ USAGE:
     erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
 
 lex
-    Receive input from <filename>.er, REPL, etc., and tokenize the text
-    Returns analysis results as TokenStream
+    Receive input from <filename>.er, REPL, etc. and lex the text
+    Returns the analysis results as s a TokenStream
 
 parse
-    Execute lexing, parsing & desugaring then return AST (abstract syntax tree)
+    Executes lex to get TokenStream, and parses it
+    Degenerate and return AST (Abstract Syntax Tree)
 
 lower
-    Execute parsing
-    Resolve name, check type and infer, and return HIR (High-Level Intermediate Representation)
+    Execute parse to obtain AST
+    Performs name resolution, type checking, and type inference, and returns HIR (High-level Intermediate Representation)
 
 check
-    Execute lowering
-    Check side-effects, ownership and return HIR
+    Execute lower
+    Checks for side-effects, ownership, and returns HIR
 
 compile
     Execute check
-    Compile HIR and return <filename>.pyc
+    Generates bytecode from HIR and outputs <filename>.pyc
 
 exec
-    Execute compiling & executing <filename>.pyc
+    Execute compile and then <filename>.pyc
 
 read
-    Deserialize <filename>.pyc and dump",
+    Deserialize <filename>.pyc and dump code object information",
     )
 }

--- a/compiler/erg_common/help_messages.rs
+++ b/compiler/erg_common/help_messages.rs
@@ -131,38 +131,6 @@ exec
 read
     <filename>.pycをデシリアライズしダンプ",
 
-    "simplified_chinese" =>
-        "\
-USAGE:
-    erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
-
-lex
-    Receive input from <filename>.er, REPL, etc., and tokenize the text
-    Returns analysis results as TokenStream
-
-parse
-    Execute lex, get TokenStream, and parse the syntax
-    Desugar multiple pattern definition sentences, convert by match and return ast (abstract syntax tree)
-
-lower
-    Execute parse to get ast
-    Resolve name, check type and infer, and return ast
-
-check
-    Execute lower and get ast
-    Check side-effects, ownership and return ast
-
-compile
-    Run check to get checked ast
-    Compile ast and return <filename>.pyc
-
-exec
-    Execute check to get checked ast
-    Delete <filename>.pyc after executing <filename>.pyc
-
-read
-    Deserialize <filename>.pyc and dump",
-
     "traditional_chinese" =>
         "\
 USAGE:
@@ -195,7 +163,7 @@ exec
 read
     反序列化 <filename>.pyc 并转储",
 
-    "english" =>
+    "simplified_chinese" =>
         "\
 USAGE:
     erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
@@ -226,5 +194,37 @@ exec
 
 read
     反序列化 <filename>.pyc 並轉儲",
+
+    "english" =>
+        "\
+USAGE:
+    erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
+
+lex
+    Receive input from <filename>.er, REPL, etc., and tokenize the text
+    Returns analysis results as TokenStream
+
+parse
+    Execute lex, get TokenStream, and parse the syntax
+    Desugar multiple pattern definition sentences, convert by match and return ast (abstract syntax tree)
+
+lower
+    Execute parse to get ast
+    Resolve name, check type and infer, and return ast
+
+check
+    Execute lower and get ast
+    Check side-effects, ownership and return ast
+
+compile
+    Run check to get checked ast
+    Compile ast and return <filename>.pyc
+
+exec
+    Execute check to get checked ast
+    Delete <filename>.pyc after executing <filename>.pyc
+
+read
+    Deserialize <filename>.pyc and dump",
     )
 }

--- a/compiler/erg_common/help_messages.rs
+++ b/compiler/erg_common/help_messages.rs
@@ -30,11 +30,11 @@ SUBCOMMAND
     "\
 USAGE:
     erg [OPTIONS] [SUBCOMMAND] [ARGS]...
-    
+
 ARGS:
     <script> 从脚本文件读取程序
             参数也可以指定要传递给 <script>
-    
+
 OPTIONS
     --help/-?/-h                         显示帮助
     --version/-V                         显示版本
@@ -44,7 +44,7 @@ OPTIONS
     --py-server-timeout (uint 64 number) Python REPL 服务器超时
     --dump-as-pyc                        转储为 .pyc 文件
     --mode lex|parse|compile|exec        执行模式
-    
+
 SUBCOMMAND
     -c cmd : 作为字符串传入程序
     -m mod : 要执行的模块",
@@ -110,26 +110,25 @@ lex
 
 parse
     lexを実行し、TokenStreamを獲得して構文を解析
-    脱糖衣し複数パターン定義文をmatchで変換しast(抽象構文木)を返す
+    脱糖しAST(抽象構文木)を返す
 
 lower
-    parseを実行し、astを獲得
-    名前解決、型チェックと推論しastを返す
+    parseを実行し、ASTを獲得
+    名前解決、型検査・型推論をしてHIR(高レベル中間表現)を返す
 
 check
-    lowerを実行しastを獲得
-    副作用、所有権を確認しastを返す
+    lowerを実行
+    副作用、所有権を確認しHIRを返す
 
 compile
-    checkを実行しチェックされたastを獲得
-    astをコンパイルし、<filename>.pycを返す
+    checkを実行
+    HIRをからバイトコードを生成し、<filename>.pycを出力する
 
 exec
-    checkを実行しチェックされたastを獲得
-    <filename>.pycを実行後、<filename>.pycを削除
+    compileを実行し、更に<filename>.pycを実行
 
 read
-    <filename>.pycをデシリアライズしダンプ",
+    <filename>.pycをデシリアライズしコードオブジェクトの情報をダンプ",
 
     "simplified_chinese" =>
     "\
@@ -142,22 +141,22 @@ lex
 
 parse
     执行 lex, 获取 TokenStream, 并解析语法
-    将多模式定义语句的语法糖按匹配转换并返回ast(抽象语法树)
+    将多模式定义语句的语法糖按匹配转换并返回AST(抽象语法树)
 
 lower
-    执行 parse 以获取 ast
-    解析名称、检查类型和推断, 并返回 ast
+    执行 parse 以获取 AST
+    解析名称、检查类型和推断, 并返回 AST
 
 check
-    执行 lower 并获取 ast
-    检查副作用、所有权并返回 ast
+    执行 lower 并获取 AST
+    检查副作用、所有权并返回 AST
 
 compile
-    运行 check 以获取检查完成的 ast
-    编译 ast 并返回 <文件名>.pyc
+    运行 check 以获取检查完成的 AST
+    编译 AST 并返回 <文件名>.pyc
 
 exec
-    运行 check 以获取检查完成的 ast
+    运行 check 以获取检查完成的 AST
     在执行 <filename>.pyc 后删除 <文件名>.pyc
 
 read
@@ -167,31 +166,31 @@ read
     "\
 USAGE:
         erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
-    
+
 lex
     從 <檔名>.er, REPL 等接受輸入, 並標記文字
     以 TokenStream 形式返回分析結果
-    
+
 parse
     執行 lex, 獲取 TokenStream, 並解析語法
-    將多模式定義語句的語法糖按匹配轉換並返回 ast(抽象語法樹)
-    
+    將多模式定義語句的語法糖按匹配轉換並返回 AST(抽象語法樹)
+
 lower
-    執行 parse 以獲取 ast
-    解析名稱、檢查類型和推斷, 並返回 ast
-    
+    執行 parse 以獲取AST
+    解析名稱、檢查類型和推斷, 並返回HIR
+
 check
-    執行 lower 並獲取 ast
-    檢查副作用、所有權並返回 ast
-    
+    執行 lower 並獲取 AST
+    檢查副作用、所有權並返回 AST
+
 compile
-    運行 check 以獲取檢查完成的 ast
-    編譯 ast 並返回 <檔名>.pyc
-    
+    運行 check 以獲取檢查完成的 AST
+    編譯 AST 並返回 <檔名>.pyc
+
 exec
-    運行check以獲取檢查完成的ast
+    運行check以獲取檢查完成的AST
     在執行<檔名>.pyc後删除<檔名>.pyc
-    
+
 read
     反序列化 <檔名>.pyc 和 dump",
 
@@ -205,24 +204,22 @@ lex
     Returns analysis results as TokenStream
 
 parse
-    Execute lex, get TokenStream, and parse the syntax
-    Desugar multiple pattern definition sentences, convert by match and return ast (abstract syntax tree)
+    Execute lexing, parsing & desugaring then return AST (abstract syntax tree)
 
 lower
-    Execute parse to get ast
-    Resolve name, check type and infer, and return ast
+    Execute parsing
+    Resolve name, check type and infer, and return HIR (High-Level Intermediate Representation)
 
 check
-    Execute lower and get ast
-    Check side-effects, ownership and return ast
+    Execute lowering
+    Check side-effects, ownership and return AST
 
 compile
-    Run check to get checked ast
-    Compile ast and return <filename>.pyc
+    Execute check
+    Compile AST and return <filename>.pyc
 
 exec
-    Execute check to get checked ast
-    Delete <filename>.pyc after executing <filename>.pyc
+    Execute compiling & executing <filename>.pyc
 
 read
     Deserialize <filename>.pyc and dump",

--- a/compiler/erg_common/help_messages.rs
+++ b/compiler/erg_common/help_messages.rs
@@ -1,29 +1,10 @@
+use crate::switch_lang;
+
 /// erg -h/--help/-?
-#[cfg(not(feature = "japanese"))]
-pub const CMD_HELP: &str = "\
-USAGE:
-    erg [OPTIONS] [SUBCOMMAND] [ARGS]...
-
-ARGS:
-    <script> program read from script file
-             Arguments can also be specified to be passed to the <script>
-
-OPTIONS
-    --help/-?/-h                         show this help
-    --version/-V                         show version
-    --verbose 0|1|2                      verbosity level
-    --opt-level/-o 0|1|2|3               optimization level
-    --python-version/-p (uint 32 number) Python version
-    --py-server-timeout (uint 64 number) timeout for the Python REPL server
-    --dump-as-pyc                        dump as .pyc file
-    --mode lex|parse|compile|exec        execution mode
-
-SUBCOMMAND
-    -c cmd : program passed in as string
-    -m mod : module to be executed";
-
-#[cfg(feature = "japanese")]
-pub const CMD_HELP: &str = "\
+pub fn command_message<'a>() -> &'a str {
+    switch_lang!(
+        "japanese" =>
+        "\
 USAGE:
     erg [OPTIONS] [SUBCOMMAND] [ARGS]...
 
@@ -34,19 +15,65 @@ ARGS:
 OPTIONS
     --help/-?/-h                         このhelpを表示
     --version/-V                         バージョンを表示
-    --verbose 0|1|2                      冗長化レベル
-    --opt-level/-o 0|1|2|3               最適化レベル
+    --verbose 0|1|2                      冗長性レベルを指定
+    --opt-level/-o 0|1|2|3               最適化レベルを指定
     --python-version/-p (uint 32 number) Pythonバージョンを指定
-    --py-server-timeout (uint 64 number) PythonのREPLサーバーのタイムアプト時間を指定
+    --py-server-timeout (uint 64 number) PythonのREPLサーバーのタイムアウト時間を指定
     --dump-as-pyc                        .pycファイルにダンプ
-    --mode lex|parse|compile|exec        モードで実行
+    --mode lex|parse|compile|exec        指定モードで実行
 
 SUBCOMMAND
-    -c cmd : 文字列をプログラムに渡す
-    -m mod : モジュールを実行させる";
+    -c cmd : 文字列をプログラムに譲渡
+    -m mod : モジュールを実行",
 
-#[cfg(feature = "simplified_chinese")]
-pub const CMD_HELP: &str = "\
+    "simplified_chinese" =>
+        "\
+USAGE:
+    erg [OPTIONS] [SUBCOMMAND] [ARGS]...
+
+ARGS:
+    <script> 從腳本文件中讀取的程序
+             參數也可以指定傳遞給 <script>
+
+OPTIONS
+    --help/-?/-h                         显示此帮助
+    --version/-V                         显示版本
+    --verbose 0|1|2                      详细程度
+    --opt-level/-o 0|1|2|3               优化级别
+    --python-version/-p (uint 32 number) Python版本
+    --py-server-timeout (uint 64 number) Python REPL服务器超时
+    --dump-as-pyc                        转储为 .pyc 文件
+    --mode lex|parse|compile|exec        执行模式
+
+SUBCOMMAND
+    -c cmd : 作为字符串传入的程序
+    -m mod : 要执行的模块",
+
+    "traditional_chinese" =>
+        "\
+USAGE:
+    erg [OPTIONS] [SUBCOMMAND] [ARGS]...
+
+ARGS:
+    <script> 从脚本文件中读取的程序
+             参数也可以指定传递给 <script>
+
+OPTIONS
+    --help/-?/-h                         顯示此幫助
+    --version/-V                         顯示版本
+    --verbose 0|1|2                      詳細程度
+    --opt-level/-o 0|1|2|3               優化級別
+    --python-version/-p (uint 32 number) Python 版本
+    --py-server-timeout (uint 64 number) Python REPL 服務器超時
+    --dump-as-pyc                        轉儲為 .pyc 文件
+    --mode lex|parse|compile|exec        執行模式
+
+SUBCOMMAND
+    -c cmd : 作為字符串傳入的程序
+    -m mod : 要執行的模塊",
+
+    "english" =>
+        "\
 USAGE:
     erg [OPTIONS] [SUBCOMMAND] [ARGS]...
 
@@ -66,159 +93,138 @@ OPTIONS
 
 SUBCOMMAND
     -c cmd : program passed in as string
-    -m mod : module to be executed";
+    -m mod : module to be executed",
+    )
+}
 
-#[cfg(feature = "traditional_chinese")]
-pub const CMD_HELP: &str = "\
-USAGE:
-    erg [OPTIONS] [SUBCOMMAND] [ARGS]...
-
-ARGS:
-    <script> program read from script file
-             Arguments can also be specified to be passed to the <script>
-
-OPTIONS
-    --help/-?/-h                         show this help
-    --version/-V                         show version
-    --verbose 0|1|2                      verbosity level
-    --opt-level/-o 0|1|2|3               optimization level
-    --python-version/-p (uint 32 number) Python version
-    --py-server-timeout (uint 64 number) timeout for the Python REPL server
-    --dump-as-pyc                        dump as .pyc file
-    --mode lex|parse|compile|exec        execution mode
-
-SUBCOMMAND
-    -c cmd : program passed in as string
-    -m mod : module to be executed";
-
-/// erg --mode -h/--help/-?
-#[cfg(not(feature = "japanese"))]
-pub const MODE_HELP: &str = "\
+pub fn mode_message<'a>() -> &'a str {
+    switch_lang!(
+        "japanese" =>
+        "\
 USAGE:
     erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
 
 lex
-    Takes input from a .er file or REPL strings, and lexes them into erg tokens
-    The lexed string becomes an iterator as TokenStream
+    <filename>.erやREPLなどから入力を受け取り、字句を解析
+    解析結果をTokenStreamとして返す
 
 parse
-    Exec lex and get TokenStream
-    Iterate TokenStream and confirm that it fits the erg grammar
-    TokenStream is reduced to Module
+    lexを実行し、TokenStreamを獲得して構文を解析
+    脱糖衣し複数パターン定義文をmatchで変換しast(抽象構文木)を返す
 
 lower
-    Exec parse and get module
-    Module is converted ast(abstract syntax tree)
-
-check
-    Exec lower and get module
-    Borrow checks at ast
-
-compile
-    Exec check and get ast
-    Compile ast to o.pyc file
-
-exec
-    exec the compiled o.pyc
-
-read
-    read the .pyc, and out put to .er file";
-
-#[cfg(feature = "japanese")]
-pub const MODE_HELP: &str = "\
-USAGE:
-    erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
-
-lex
-    .erファイルやREPLなどから入力を受け取り、それを字句解析
-    字句解析された文字列のtokenをTokenStreamとして収集
-
-parse
-    lexを実行し、TokenStreamを獲得
-    TokenStreamをイテレートし、ergの構文解析
-    TokenStreamをmoduleに還元
-
-lower
-    parseを実行し、moduleを獲得
-    moduleをast(抽象構文木)に変換
+    parseを実行し、astを獲得
+    名前解決、型チェックと推論しastを返す
 
 check
     lowerを実行しastを獲得
-    astの借用チェック
+    副作用、所有権を確認しastを返す
 
 compile
-    checkを実行し借用チェックされたastを獲得
-    astをo.pycにコンパイル
+    checkを実行しチェックされたastを獲得
+    astをコンパイルし、<filename>.pycを返す
 
 exec
-    compileを実行し、o.pycを獲得
-    o.pycを実行
+    checkを実行しチェックされたastを獲得
+    <filename>.pycを実行後、<filename>.pycを削除
 
 read
-    o.pycを読み取り、ergのastに変換";
+    <filename>.pycをデシリアライズしダンプ",
 
-#[cfg(feature = "simplified_chinese")]
-pub const MODE_HELP: &str = "\
+    "simplified_chinese" =>
+        "\
 USAGE:
     erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
 
 lex
-    TODO
-    TODO
+    Receive input from <filename>.er, REPL, etc., and tokenize the text
+    Returns analysis results as TokenStream
 
 parse
-    TODO
-    TODO
-    TODO
+    Execute lex, get TokenStream, and parse the syntax
+    Desugar multiple pattern definition sentences, convert by match and return ast (abstract syntax tree)
 
 lower
-    TODO
-    TODO
+    Execute parse to get ast
+    Resolve name, check type and infer, and return ast
 
 check
-    TODO
-    TODO
+    Execute lower and get ast
+    Check side-effects, ownership and return ast
 
 compile
-    TODO
-    TODO
+    Run check to get checked ast
+    Compile ast and return <filename>.pyc
 
 exec
-    TODO
-    TODO
+    Execute check to get checked ast
+    Delete <filename>.pyc after executing <filename>.pyc
 
 read
-    TODO";
+    Deserialize <filename>.pyc and dump",
 
-#[cfg(feature = "traditional_chinese")]
-pub const MODE_HELP: &str = "\
+    "traditional_chinese" =>
+        "\
 USAGE:
     erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
 
 lex
-    TODO
-    TODO
+    从 <filename>.er、REPL 等接收输入，并标记文本
+    以 TokenStream 形式返回分析结果
 
 parse
-    TODO
-    TODO
-    TODO
+    执行lex，获取TokenStream，解析语法
+    对多个模式定义语句进行脱糖，通过匹配转换并返回 ast（抽象语法树）
 
 lower
-    TODO
-    TODO
+    执行 parse 得到 ast
+    解析名称，检查类型和推断，并返回 ast
 
 check
-    TODO
-    TODO
+    执行lower并get ast
+    检查副作用、所有权和回报
 
 compile
-    TODO
-    TODO
+    運行檢查以檢查 ast
+    編譯 ast 並返回 <filename>.pyc
 
 exec
-    TODO
-    TODO
+    执行检查以检查 ast
+    执行 <filename>.pyc 后删除 <filename>.pyc
 
 read
-    TODO";
+    反序列化 <filename>.pyc 并转储",
+
+    "english" =>
+        "\
+USAGE:
+    erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
+
+lex
+    從 <filename>.er、REPL 等接收輸入，並標記文本
+    以 TokenStream 形式返回分析結果
+
+parse
+    執行lex，獲取TokenStream，解析語法
+    對多個模式定義語句進行脫糖，通過匹配轉換並返回 ast（抽象語法樹）
+
+lower
+    執行 parse 得到 ast
+    解析名稱，檢查類型和推斷，並返回 ast
+
+check
+    執行lower並get ast
+    檢查副作用、所有權和回報
+
+compile
+    运行检查以检查 ast
+    编译 ast 并返回 <filename>.pyc
+
+exec
+    執行檢查以檢查 ast
+    執行 <filename>.pyc 後刪除 <filename>.pyc
+
+read
+    反序列化 <filename>.pyc 並轉儲",
+    )
+}

--- a/compiler/erg_common/help_messages.rs
+++ b/compiler/erg_common/help_messages.rs
@@ -201,7 +201,7 @@ USAGE:
 
 lex
     Receive input from <filename>.er, REPL, etc. and lex the text
-    Returns the analysis results as s a TokenStream
+    Returns the analysis results as a TokenStream
 
 parse
     Executes lex to get TokenStream, and parses it

--- a/compiler/erg_common/help_messages.rs
+++ b/compiler/erg_common/help_messages.rs
@@ -1,0 +1,224 @@
+/// erg -h/--help/-?
+#[cfg(not(feature = "japanese"))]
+pub const CMD_HELP: &str = "\
+USAGE:
+    erg [OPTIONS] [SUBCOMMAND] [ARGS]...
+
+ARGS:
+    <script> program read from script file
+             Arguments can also be specified to be passed to the <script>
+
+OPTIONS
+    --help/-?/-h                         show this help
+    --version/-V                         show version
+    --verbose 0|1|2                      verbosity level
+    --opt-level/-o 0|1|2|3               optimization level
+    --python-version/-p (uint 32 number) Python version
+    --py-server-timeout (uint 64 number) timeout for the Python REPL server
+    --dump-as-pyc                        dump as .pyc file
+    --mode lex|parse|compile|exec        execution mode
+
+SUBCOMMAND
+    -c cmd : program passed in as string
+    -m mod : module to be executed";
+
+#[cfg(feature = "japanese")]
+pub const CMD_HELP: &str = "\
+USAGE:
+    erg [OPTIONS] [SUBCOMMAND] [ARGS]...
+
+ARGS:
+    <script> スクリプトファイルからプログラムを読み込む
+             <script>に渡す引数を入力する
+
+OPTIONS
+    --help/-?/-h                         このhelpを表示
+    --version/-V                         バージョンを表示
+    --verbose 0|1|2                      冗長化レベル
+    --opt-level/-o 0|1|2|3               最適化レベル
+    --python-version/-p (uint 32 number) Pythonバージョンを指定
+    --py-server-timeout (uint 64 number) PythonのREPLサーバーのタイムアプト時間を指定
+    --dump-as-pyc                        .pycファイルにダンプ
+    --mode lex|parse|compile|exec        モードで実行
+
+SUBCOMMAND
+    -c cmd : 文字列をプログラムに渡す
+    -m mod : モジュールを実行させる";
+
+#[cfg(feature = "simplified_chinese")]
+pub const CMD_HELP: &str = "\
+USAGE:
+    erg [OPTIONS] [SUBCOMMAND] [ARGS]...
+
+ARGS:
+    <script> program read from script file
+             Arguments can also be specified to be passed to the <script>
+
+OPTIONS
+    --help/-?/-h                         show this help
+    --version/-V                         show version
+    --verbose 0|1|2                      verbosity level
+    --opt-level/-o 0|1|2|3               optimization level
+    --python-version/-p (uint 32 number) Python version
+    --py-server-timeout (uint 64 number) timeout for the Python REPL server
+    --dump-as-pyc                        dump as .pyc file
+    --mode lex|parse|compile|exec        execution mode
+
+SUBCOMMAND
+    -c cmd : program passed in as string
+    -m mod : module to be executed";
+
+#[cfg(feature = "traditional_chinese")]
+pub const CMD_HELP: &str = "\
+USAGE:
+    erg [OPTIONS] [SUBCOMMAND] [ARGS]...
+
+ARGS:
+    <script> program read from script file
+             Arguments can also be specified to be passed to the <script>
+
+OPTIONS
+    --help/-?/-h                         show this help
+    --version/-V                         show version
+    --verbose 0|1|2                      verbosity level
+    --opt-level/-o 0|1|2|3               optimization level
+    --python-version/-p (uint 32 number) Python version
+    --py-server-timeout (uint 64 number) timeout for the Python REPL server
+    --dump-as-pyc                        dump as .pyc file
+    --mode lex|parse|compile|exec        execution mode
+
+SUBCOMMAND
+    -c cmd : program passed in as string
+    -m mod : module to be executed";
+
+/// erg --mode -h/--help/-?
+#[cfg(not(feature = "japanese"))]
+pub const MODE_HELP: &str = "\
+USAGE:
+    erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
+
+lex
+    Takes input from a .er file or REPL strings, and lexes them into erg tokens
+    The lexed string becomes an iterator as TokenStream
+
+parse
+    Exec lex and get TokenStream
+    Iterate TokenStream and confirm that it fits the erg grammar
+    TokenStream is reduced to Module
+
+lower
+    Exec parse and get module
+    Module is converted ast(abstract syntax tree)
+
+check
+    Exec lower and get module
+    Borrow checks at ast
+
+compile
+    Exec check and get ast
+    Compile ast to o.pyc file
+
+exec
+    exec the compiled o.pyc
+
+read
+    read the .pyc, and out put to .er file";
+
+#[cfg(feature = "japanese")]
+pub const MODE_HELP: &str = "\
+USAGE:
+    erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
+
+lex
+    .erファイルやREPLなどから入力を受け取り、それを字句解析
+    字句解析された文字列のtokenをTokenStreamとして収集
+
+parse
+    lexを実行し、TokenStreamを獲得
+    TokenStreamをイテレートし、ergの構文解析
+    TokenStreamをmoduleに還元
+
+lower
+    parseを実行し、moduleを獲得
+    moduleをast(抽象構文木)に変換
+
+check
+    lowerを実行しastを獲得
+    astの借用チェック
+
+compile
+    checkを実行し借用チェックされたastを獲得
+    astをo.pycにコンパイル
+
+exec
+    compileを実行し、o.pycを獲得
+    o.pycを実行
+
+read
+    o.pycを読み取り、ergのastに変換";
+
+#[cfg(feature = "simplified_chinese")]
+pub const MODE_HELP: &str = "\
+USAGE:
+    erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
+
+lex
+    TODO
+    TODO
+
+parse
+    TODO
+    TODO
+    TODO
+
+lower
+    TODO
+    TODO
+
+check
+    TODO
+    TODO
+
+compile
+    TODO
+    TODO
+
+exec
+    TODO
+    TODO
+
+read
+    TODO";
+
+#[cfg(feature = "traditional_chinese")]
+pub const MODE_HELP: &str = "\
+USAGE:
+    erg --mode [lex | parse | lower | check | compile | exec | read] [SUBCOMMAND] [ARGS]...
+
+lex
+    TODO
+    TODO
+
+parse
+    TODO
+    TODO
+    TODO
+
+lower
+    TODO
+    TODO
+
+check
+    TODO
+    TODO
+
+compile
+    TODO
+    TODO
+
+exec
+    TODO
+    TODO
+
+read
+    TODO";

--- a/compiler/erg_common/lib.rs
+++ b/compiler/erg_common/lib.rs
@@ -9,6 +9,7 @@ pub mod datetime;
 pub mod dict;
 pub mod error;
 pub mod fxhash;
+pub mod help_messages;
 pub mod levenshtein;
 pub mod macros;
 pub mod opcode;


### PR DESCRIPTION
When feature flag is specified, comments are switched to the respective language.
This can be used to switch help commands as well.
Translate from Japanese text to EN and CH.

- [x] Help command review
    - [x] JA
    - [x] EN
    - [x] zh_CN
    - [x] zh_TW
- [x] Mode help command review
    - [x] JA
    - [x] EN
    - [x] zh_CN
    - [x] zh_TW

Unwrap() is often used to parse arguments, causing panic with wrong arguments.

Changes proposed in this PR:
- Possible to localize to help command
- Add help_message.rs
- Error handling of args parsing (Shouldn't this be included?)

@mtshiba
