### PR TITLE
Enable shortened/normal mixed record definition

### DIFF
--- a/compiler/erg_compiler/context/eval.rs
+++ b/compiler/erg_compiler/context/eval.rs
@@ -309,7 +309,7 @@ impl Context {
     fn eval_const_record(&self, record: &Record) -> EvalResult<ValueObj> {
         match record {
             Record::Normal(rec) => self.eval_const_normal_record(rec),
-            Record::Shortened(_rec) => unreachable!(), // should be desugared
+            Record::Mixed(_rec) => unreachable!(), // should be desugared
         }
     }
 

--- a/compiler/erg_compiler/context/inquire.rs
+++ b/compiler/erg_compiler/context/inquire.rs
@@ -8,7 +8,7 @@ use erg_common::error::{ErrorCore, ErrorKind, Location};
 use erg_common::levenshtein::get_similar_name;
 use erg_common::set::Set;
 use erg_common::traits::{Locational, Stream};
-use erg_common::vis::{Field, Visibility};
+use erg_common::vis::Visibility;
 use erg_common::{enum_unwrap, fmt_option, fmt_slice, log, set};
 use erg_common::{option_enum_unwrap, Str};
 use Type::*;
@@ -530,8 +530,7 @@ impl Context {
                 self.get_attr_info_from_attributive(&refine.t, ident, namespace)
             }
             Type::Record(record) => {
-                // REVIEW: `rec.get(name.inspect())` returns None (Borrow<Str> is implemented for Field). Why?
-                if let Some(attr_t) = record.get(&Field::new(Public, ident.inspect().clone())) {
+                if let Some(attr_t) = record.get(ident.inspect()) {
                     let muty = Mutability::from(&ident.inspect()[..]);
                     let vi = VarInfo::new(
                         attr_t.clone(),

--- a/compiler/erg_compiler/lower.rs
+++ b/compiler/erg_compiler/lower.rs
@@ -330,7 +330,7 @@ impl ASTLowerer {
         log!(info "entered {}({record})", fn_name!());
         match record {
             ast::Record::Normal(rec) => self.lower_normal_record(rec),
-            ast::Record::Shortened(_rec) => unreachable!(), // should be desugared
+            ast::Record::Mixed(_rec) => unreachable!(), // should be desugared
         }
     }
 

--- a/compiler/erg_parser/ast.rs
+++ b/compiler/erg_parser/ast.rs
@@ -360,9 +360,9 @@ impl Subscript {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TypeAppArgs {
-    l_vbar: Token,
+    pub l_vbar: Token,
     pub args: Args,
-    r_vbar: Token,
+    pub r_vbar: Token,
 }
 
 impl NestedDisplay for TypeAppArgs {
@@ -445,6 +445,10 @@ impl Accessor {
 
     pub fn subscr(obj: Expr, index: Expr, r_sqbr: Token) -> Self {
         Self::Subscr(Subscript::new(obj, index, r_sqbr))
+    }
+
+    pub fn type_app(obj: Expr, type_args: TypeAppArgs) -> Self {
+        Self::TypeApp(TypeApp::new(obj, type_args))
     }
 
     pub const fn name(&self) -> Option<&Str> {
@@ -878,6 +882,16 @@ impl NestedDisplay for MixedRecord {
 
 impl_display_from_nested!(MixedRecord);
 impl_locational!(MixedRecord, l_brace, r_brace);
+
+impl MixedRecord {
+    pub fn new(l_brace: Token, r_brace: Token, attrs: Vec<RecordAttrOrIdent>) -> Self {
+        Self {
+            l_brace,
+            r_brace,
+            attrs,
+        }
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum RecordAttrOrIdent {
@@ -3495,6 +3509,10 @@ impl Expr {
 
     pub fn tuple_attr_expr(self, index: Literal) -> Self {
         Self::Accessor(self.tuple_attr(index))
+    }
+
+    pub fn type_app(self, type_args: TypeAppArgs) -> Accessor {
+        Accessor::type_app(self, type_args)
     }
 
     pub fn call(self, args: Args) -> Call {

--- a/compiler/erg_parser/desugar.rs
+++ b/compiler/erg_parser/desugar.rs
@@ -12,12 +12,12 @@ use erg_common::{enum_unwrap, get_hash, log, set};
 
 use crate::ast::{
     Accessor, Args, Array, ArrayComprehension, ArrayTypeSpec, ArrayWithLength, BinOp, Block, Call,
-    ClassAttr, ClassAttrs, ConstExpr, DataPack, Def, DefBody, DefId, Dict, Expr, Identifier,
-    KeyValue, KwArg, Lambda, LambdaSignature, Literal, Methods, MixedRecord, Module,
+    ClassAttr, ClassAttrs, ClassDef, ConstExpr, DataPack, Def, DefBody, DefId, Dict, Expr,
+    Identifier, KeyValue, KwArg, Lambda, LambdaSignature, Literal, Methods, MixedRecord, Module,
     NonDefaultParamSignature, NormalArray, NormalDict, NormalRecord, NormalSet, NormalTuple,
     ParamPattern, ParamRecordAttr, Params, PosArg, Record, RecordAttrOrIdent, RecordAttrs,
-    Set as astSet, SetWithLength, Signature, SubrSignature, Tuple, TypeBoundSpecs, TypeSpec,
-    TypeSpecWithOp, UnaryOp, VarName, VarPattern, VarRecordAttr, VarSignature,
+    Set as astSet, SetWithLength, Signature, SubrSignature, Tuple, TypeAppArgs, TypeBoundSpecs,
+    TypeSpec, TypeSpecWithOp, UnaryOp, VarName, VarPattern, VarRecordAttr, VarSignature,
 };
 use crate::token::{Token, TokenKind, COLON, DOT};
 
@@ -63,8 +63,25 @@ impl Desugarer {
         module.into_iter().map(desugar).collect()
     }
 
+    fn desugar_args(mut desugar: impl FnMut(Expr) -> Expr, args: Args) -> Args {
+        let (pos_args, kw_args, paren) = args.deconstruct();
+        let pos_args = pos_args
+            .into_iter()
+            .map(|arg| PosArg::new(desugar(arg.expr)))
+            .collect();
+        let kw_args = kw_args
+            .into_iter()
+            .map(|arg| {
+                let expr = desugar(arg.expr);
+                KwArg::new(arg.keyword, arg.t_spec, expr) // TODO: t_spec
+            })
+            .collect();
+        Args::new(pos_args, kw_args, paren)
+    }
+
     fn perform_desugar(mut desugar: impl FnMut(Expr) -> Expr, expr: Expr) -> Expr {
         match expr {
+            Expr::Lit(_) => expr,
             Expr::Record(record) => match record {
                 Record::Normal(rec) => {
                     let mut new_attrs = vec![];
@@ -77,7 +94,28 @@ impl Desugarer {
                         RecordAttrs::new(new_attrs),
                     )))
                 }
-                shorten => Expr::Record(shorten),
+                Record::Mixed(mixed) => {
+                    let mut new_attrs = vec![];
+                    for attr in mixed.attrs {
+                        match attr {
+                            RecordAttrOrIdent::Attr(attr) => {
+                                let attr = RecordAttrOrIdent::Attr(enum_unwrap!(
+                                    desugar(Expr::Def(attr)),
+                                    Expr::Def
+                                ));
+                                new_attrs.push(attr);
+                            }
+                            RecordAttrOrIdent::Ident(ident) => {
+                                new_attrs.push(RecordAttrOrIdent::Ident(ident));
+                            }
+                        }
+                    }
+                    Expr::Record(Record::Mixed(MixedRecord::new(
+                        mixed.l_brace,
+                        mixed.r_brace,
+                        new_attrs,
+                    )))
+                }
             },
             Expr::DataPack(pack) => {
                 let class = desugar(*pack.class);
@@ -173,19 +211,7 @@ impl Desugarer {
             }
             Expr::Call(call) => {
                 let obj = desugar(*call.obj);
-                let (pos_args, kw_args, paren) = call.args.deconstruct();
-                let pos_args = pos_args
-                    .into_iter()
-                    .map(|arg| PosArg::new(desugar(arg.expr)))
-                    .collect();
-                let kw_args = kw_args
-                    .into_iter()
-                    .map(|arg| {
-                        let expr = desugar(arg.expr);
-                        KwArg::new(arg.keyword, arg.t_spec, expr) // TODO: t_spec
-                    })
-                    .collect();
-                let args = Args::new(pos_args, kw_args, paren);
+                let args = Self::desugar_args(desugar, call.args);
                 Expr::Call(Call::new(obj, call.attr_name, args))
             }
             Expr::Def(def) => {
@@ -195,6 +221,15 @@ impl Desugarer {
                 }
                 let body = DefBody::new(def.body.op, Block::new(chunks), def.body.id);
                 Expr::Def(Def::new(def.sig, body))
+            }
+            Expr::ClassDef(class_def) => {
+                let def = enum_unwrap!(desugar(Expr::Def(class_def.def)), Expr::Def);
+                let methods = class_def
+                    .methods_list
+                    .into_iter()
+                    .map(|method| enum_unwrap!(desugar(Expr::Methods(method)), Expr::Methods))
+                    .collect();
+                Expr::ClassDef(ClassDef::new(def, methods))
             }
             Expr::Lambda(lambda) => {
                 let mut chunks = vec![];
@@ -229,8 +264,29 @@ impl Desugarer {
                 let new_attrs = ClassAttrs::from(new_attrs);
                 Expr::Methods(Methods::new(method_defs.class, method_defs.vis, new_attrs))
             }
-            // TODO: Accessor
-            other => other,
+            Expr::Accessor(acc) => {
+                let acc = match acc {
+                    Accessor::Ident(ident) => Accessor::Ident(ident),
+                    Accessor::Attr(attr) => desugar(*attr.obj).attr(attr.ident),
+                    Accessor::TupleAttr(tup) => {
+                        let obj = desugar(*tup.obj);
+                        obj.tuple_attr(tup.index)
+                    }
+                    Accessor::Subscr(sub) => {
+                        let obj = desugar(*sub.obj);
+                        let index = desugar(*sub.index);
+                        obj.subscr(index, sub.r_sqbr)
+                    }
+                    Accessor::TypeApp(tapp) => {
+                        let obj = desugar(*tapp.obj);
+                        let args = Self::desugar_args(desugar, tapp.type_args.args);
+                        let type_args =
+                            TypeAppArgs::new(tapp.type_args.l_vbar, args, tapp.type_args.r_vbar);
+                        obj.type_app(type_args)
+                    }
+                };
+                Expr::Accessor(acc)
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #238.

Enable record definition in mixed style:
```erg
x = 1
z = 100
t = {x; y = 10; z}
print! t.x  # prints 1
print! t.y  # prints 10
print! t.z  # prints 100
```

@mtshiba
