### PR TITLE
Display multiline error message

### DIFF
--- a/compiler/erg_common/config.rs
+++ b/compiler/erg_common/config.rs
@@ -106,7 +106,20 @@ impl Input {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
-            Self::REPL => GLOBAL_STDIN.reread_lines(ln_begin, ln_end),
+            Self::REPL => {
+                let ln = GLOBAL_STDIN.repl_lineno();
+                // when ln_end = 1, error location is one line
+                let lines = if ln_begin == ln_end && ln_end == 1 {
+                    vec![GLOBAL_STDIN.reread()]
+                } else {
+                    // Rows are greater than or equal to 1, but vectors start at 0, so plus one.
+                    GLOBAL_STDIN.reread_lines(ln - ln_end + 1, ln - ln_begin + 1)
+                };
+                lines
+                    .into_iter()
+                    .map(|ln| ln.trim_end().to_owned())
+                    .collect::<Vec<String>>()
+            }
             Self::Dummy => panic!("cannot read lines from a dummy file"),
         }
     }

--- a/compiler/erg_common/error.rs
+++ b/compiler/erg_common/error.rs
@@ -329,11 +329,7 @@ fn format_context<E: ErrorDisplay + ?Sized>(
     hint: Option<&String>,
 ) -> String {
     let mark = mark.to_string();
-    let codes = if e.input().is_repl() {
-        vec![e.input().reread()]
-    } else {
-        e.input().reread_lines(ln_begin, ln_end)
-    };
+    let codes = e.input().reread_lines(ln_begin, ln_end);
     let mut context = StyledStrings::default();
     let final_step = ln_end - ln_begin;
     let max_digit = ln_end.to_string().len();
@@ -496,11 +492,7 @@ impl SubMessage {
                 let input = e.input();
                 let (vbreak, vbar) = chars.gutters();
                 let mut cxt = StyledStrings::default();
-                let codes = if input.is_repl() {
-                    vec![input.reread()]
-                } else {
-                    input.reread_lines(ln_begin, ln_end)
-                };
+                let codes = input.reread_lines(ln_begin, ln_end);
                 let mark = mark.to_string();
                 for (i, lineno) in (ln_begin..=ln_end).enumerate() {
                     cxt.push_str_with_color(&format!("{lineno} {vbar} "), gutter_color);
@@ -528,11 +520,7 @@ impl SubMessage {
             Location::Line(lineno) => {
                 let input = e.input();
                 let (_, vbar) = chars.gutters();
-                let code = if input.is_repl() {
-                    input.reread()
-                } else {
-                    input.reread_lines(lineno, lineno).remove(0)
-                };
+                let code = input.reread_lines(lineno, lineno).remove(0);
                 let mut cxt = StyledStrings::default();
                 cxt.push_str_with_color(&format!(" {lineno} {} ", vbar), gutter_color);
                 cxt.push_str(&code);

--- a/compiler/erg_common/stdin.rs
+++ b/compiler/erg_common/stdin.rs
@@ -49,4 +49,8 @@ impl GlobalStdin {
         self.0
             .with(|s| s.borrow_mut().reread_lines(ln_begin, ln_end))
     }
+
+    pub fn repl_lineno(&'static self) -> usize {
+        self.0.with(|s| s.borrow().lineno)
+    }
 }


### PR DESCRIPTION
Fixes #248.

The REPL was taking out only the last line, even in the case of a multi-line error, so a blank space was displayed.

When a block is expected, ln_begin and ln_end of Range are different, so I used that to display

@mtshiba
