### PR TITLE
Fix invalid expect block and support for multi-line errors

### DIFF
--- a/crates/erg_common/error.rs
+++ b/crates/erg_common/error.rs
@@ -48,6 +48,7 @@ pub enum ErrorKind {
     VisibilityError = 20,
     MethodError = 21,
     DummyError = 22,
+    ExpectNextLine = 23,
     /* compile warnings */
     AttributeWarning = 60,
     CastWarning = 61,

--- a/crates/erg_common/io.rs
+++ b/crates/erg_common/io.rs
@@ -353,11 +353,8 @@ impl Input {
                 .map(|s| s.to_string())
                 .collect(),
             InputKind::REPL => {
-                if ln_begin == ln_end {
-                    vec![GLOBAL_STDIN.reread()]
-                } else {
-                    GLOBAL_STDIN.reread_lines(ln_begin, ln_end)
-                }
+                let block_begin = self.block_begin().saturating_sub(1);
+                GLOBAL_STDIN.reread_lines(ln_begin + block_begin, ln_end + block_begin)
             }
             InputKind::DummyREPL(dummy) => dummy.reread_lines(ln_begin, ln_end),
             InputKind::Dummy => panic!("cannot read lines from a dummy file"),

--- a/crates/erg_common/stdin.rs
+++ b/crates/erg_common/stdin.rs
@@ -302,7 +302,7 @@ impl GlobalStdin {
     }
 
     pub fn set_block_begin(&'static self, n: usize) {
-        self.get().borrow_mut().block_begin = n - 1;
+        self.get().borrow_mut().block_begin = n;
     }
 
     pub fn set_indent(&'static self, n: usize) {

--- a/crates/erg_common/stdin.rs
+++ b/crates/erg_common/stdin.rs
@@ -302,7 +302,7 @@ impl GlobalStdin {
     }
 
     pub fn set_block_begin(&'static self, n: usize) {
-        self.get().borrow_mut().block_begin = n;
+        self.get().borrow_mut().block_begin = n - 1;
     }
 
     pub fn set_indent(&'static self, n: usize) {

--- a/crates/erg_common/traits.rs
+++ b/crates/erg_common/traits.rs
@@ -817,7 +817,10 @@ pub trait Runnable: Sized + Default + New {
                                 continue;
                             }
                             match instance.eval(mem::take(&mut vm.codes)) {
-                                Ok(out) if out.is_empty() => continue,
+                                Ok(out) if out.is_empty() => {
+                                    instance.input().set_block_begin();
+                                    continue;
+                                }
                                 Ok(out) => {
                                     output.write_all((out + "\n").as_bytes()).unwrap();
                                     output.flush().unwrap();

--- a/crates/erg_common/traits.rs
+++ b/crates/erg_common/traits.rs
@@ -792,6 +792,7 @@ pub trait Runnable: Sized + Default + New {
                         ":clear" | ":cln" => {
                             output.write_all("\x1b[2J\x1b[1;1H".as_bytes()).unwrap();
                             output.flush().unwrap();
+                            instance.input().set_block_begin();
                             vm.clear();
                             instance.clear();
                             continue;
@@ -891,9 +892,6 @@ pub trait Runnable: Sized + Default + New {
                         }
                         // single eval
                         BlockKind::None => {
-                            if vm.length == 1 {
-                                instance.input().set_block_begin();
-                            }
                             vm.push_code(indent.as_str());
                             instance.input().insert_whitespace(indent.as_str());
                             vm.push_code(line);
@@ -930,9 +928,6 @@ pub trait Runnable: Sized + Default + New {
                         }
                         // expect block
                         _ => {
-                            if vm.length == 1 {
-                                instance.input().set_block_begin();
-                            }
                             vm.push_code(indent.as_str());
                             instance.input().insert_whitespace(indent.as_str());
                             vm.push_block_kind(bk);

--- a/crates/erg_compiler/transpile.rs
+++ b/crates/erg_compiler/transpile.rs
@@ -1,17 +1,18 @@
 use std::fs::File;
 use std::io::Write;
 
-use erg_common::config::{ErgConfig, TranspileTarget};
-use erg_common::dict;
-use erg_common::dict::Dict as HashMap;
-use erg_common::error::MultiErrorDisplay;
+use erg_common::error::{ErrorDisplay, ErrorKind, MultiErrorDisplay};
 use erg_common::log;
 use erg_common::set::Set as HashSet;
+use erg_common::traits::BlockKind;
 use erg_common::traits::{ExitStatus, Locational, New, Runnable, Stream};
 use erg_common::Str;
+use erg_common::{config::ErgConfig, dict};
+use erg_common::{config::TranspileTarget, dict::Dict as HashMap};
 
 use erg_parser::ast::{ParamPattern, TypeSpec, VarName, AST};
 use erg_parser::token::TokenKind;
+use erg_parser::ParserRunner;
 
 use crate::artifact::{
     BuildRunnable, Buildable, CompleteArtifact, ErrorArtifact, IncompleteArtifact,
@@ -241,6 +242,39 @@ impl Runnable for Transpiler {
         })?;
         artifact.warns.write_all_stderr();
         Ok(artifact.object.into_code())
+    }
+
+    fn expect_block(&self, src: &str) -> BlockKind {
+        let mut parser = ParserRunner::new(self.cfg().clone());
+        match parser.eval(src.to_string()) {
+            Err(errs) => {
+                let kind = errs
+                    .iter()
+                    .filter(|e| e.core().kind == ErrorKind::ExpectNextLine)
+                    .map(|e| {
+                        let msg = e.core().sub_messages.last().unwrap();
+                        // ExpectNextLine error must have msg otherwise it's a bug
+                        msg.get_msg().first().unwrap().to_owned()
+                    })
+                    .next();
+                if let Some(kind) = kind {
+                    return BlockKind::from(kind.as_str());
+                }
+                if errs
+                    .iter()
+                    .any(|err| err.core.main_message.contains("\"\"\""))
+                {
+                    return BlockKind::MultiLineStr;
+                }
+                BlockKind::Error
+            }
+            Ok(_) => {
+                if src.contains("Class") {
+                    return BlockKind::ClassDef;
+                }
+                BlockKind::None
+            }
+        }
     }
 }
 

--- a/crates/erg_parser/error.rs
+++ b/crates/erg_parser/error.rs
@@ -169,6 +169,25 @@ impl LexError {
         ))
     }
 
+    pub fn expect_next_line_error(errno: usize, loc: Location, caused: &str) -> Self {
+        Self::new(ErrorCore::new(
+            vec![SubMessage::ambiguous_new(
+                loc,
+                vec![caused.to_string()],
+                None,
+            )],
+            switch_lang!(
+                "japanese" => "ブロックが期待されていますが、EOFが与えられました",
+                "simplified_chinese" => "该块是预期的，但是是 EOF",
+                "traditional_chinese" => "該塊是預期的，但是是 EOF",
+                "english" => "The block is expected, but is EOF",
+            ),
+            errno,
+            ExpectNextLine,
+            loc,
+        ))
+    }
+
     pub fn syntax_error<S: Into<String>>(
         errno: usize,
         loc: Location,

--- a/crates/erg_parser/parse.rs
+++ b/crates/erg_parser/parse.rs
@@ -1654,6 +1654,11 @@ impl Parser {
         };
         if self.cur_is(Colon) {
             self.lpop();
+            if self.cur_is(EOF) {
+                let err = ParseError::expect_next_line_error(line!() as usize, op.loc(), "Lambda");
+                self.errs.push(err);
+                return Err(());
+            }
             let body = self
                 .try_reduce_block()
                 .map_err(|_| self.stack_dec(fn_name!()))?;
@@ -2096,6 +2101,15 @@ impl Parser {
                         break;
                     }
                     let op = self.lpop();
+                    if self.cur_is(EOF) {
+                        let err = ParseError::expect_next_line_error(
+                            line!() as usize,
+                            op.loc(),
+                            "Lambda",
+                        );
+                        self.errs.push(err);
+                        return Err(());
+                    }
                     let lhs = enum_unwrap!(stack.pop(), Some:(ExprOrOp::Expr:(_)));
                     let t_spec_as_expr = self
                         .try_reduce_expr(false, in_type_args, in_brace, false)

--- a/crates/erg_parser/parse.rs
+++ b/crates/erg_parser/parse.rs
@@ -1699,6 +1699,15 @@ impl Parser {
                 }
                 Some(op) if op.category_is(TC::DefOp) => {
                     let op = self.lpop();
+                    if self.cur_is(EOF) {
+                        let err = ParseError::expect_next_line_error(
+                            line!() as usize,
+                            op.loc(),
+                            "Assignment",
+                        );
+                        self.errs.push(err);
+                        return Err(());
+                    }
                     let is_multiline_block = self.cur_is(Newline);
                     let lhs = enum_unwrap!(stack.pop(), Some:(ExprOrOp::Expr:(_)));
                     let sig = self
@@ -1731,6 +1740,15 @@ impl Parser {
                 }
                 Some(op) if op.category_is(TC::LambdaOp) => {
                     let op = self.lpop();
+                    if self.cur_is(EOF) {
+                        let err = ParseError::expect_next_line_error(
+                            line!() as usize,
+                            op.loc(),
+                            "Lambda",
+                        );
+                        self.errs.push(err);
+                        return Err(());
+                    }
                     let is_multiline_block = self.cur_is(Newline);
                     let lhs = enum_unwrap!(stack.pop(), Some:(ExprOrOp::Expr:(_)));
                     let sig = self
@@ -2043,6 +2061,15 @@ impl Parser {
                         .convert_rhs_to_lambda_sig(lhs)
                         .map_err(|_| self.stack_dec(fn_name!()))?;
                     self.counter.inc();
+                    if self.cur_is(EOF) {
+                        let err = ParseError::expect_next_line_error(
+                            line!() as usize,
+                            op.loc(),
+                            "Lambda",
+                        );
+                        self.errs.push(err);
+                        return Err(());
+                    }
                     let block = if is_multiline_block {
                         self.try_reduce_block()
                             .map_err(|_| self.stack_dec(fn_name!()))?
@@ -2644,6 +2671,17 @@ impl Parser {
                             self.restore(vis);
                             break;
                         }
+                        EOF => {
+                            let err = ParseError::expect_next_line_error(
+                                line!() as usize,
+                                token.loc(),
+                                "ClassPub",
+                            );
+                            self.errs.push(err);
+                            self.restore(token);
+                            self.level -= 1;
+                            return Err(());
+                        }
                         _ => {
                             let err = ParseError::invalid_acc_chain(
                                 line!() as usize,
@@ -2702,6 +2740,17 @@ impl Parser {
                             self.restore(token);
                             self.restore(vis);
                             break;
+                        }
+                        EOF => {
+                            let err = ParseError::expect_next_line_error(
+                                line!() as usize,
+                                token.loc(),
+                                "ClassPriv",
+                            );
+                            self.errs.push(err);
+                            self.restore(token);
+                            self.level -= 1;
+                            return Err(());
                         }
                         _ => {
                             self.restore(token);


### PR DESCRIPTION
Fixes #58  and #248.

Each line of the REPL is now evaluated by the `Parser::eval()` (Parser and Lex are not modified)

Changes proposed in this PR:
- Add Runnable Parser to check invalid syntax
- Check invalid block as a error
- Add block_begin to use for REPL
- Display multi-line error

@mtshiba
