### PR TITLE
Avoid panicking with invalid option args

### DIFF
--- a/compiler/erg_common/config.rs
+++ b/compiler/erg_common/config.rs
@@ -384,7 +384,13 @@ impl ErgConfig {
                     process::exit(0);
                 }
                 other if other.starts_with('-') => {
-                    panic!("invalid option: {other}");
+                    println!(
+                        "\
+invalid option: {other}
+USAGE:\n    erg [OPTIONS] [SUBCOMMAND] [ARGS]...
+For more information try `erg --help`"
+                    );
+                    process::exit(0);
                 }
                 _ => {
                     cfg.input = Input::File(

--- a/compiler/erg_common/config.rs
+++ b/compiler/erg_common/config.rs
@@ -387,8 +387,11 @@ impl ErgConfig {
                     println!(
                         "\
 invalid option: {other}
-USAGE:\n    erg [OPTIONS] [SUBCOMMAND] [ARGS]...
-For more information try `erg --help`"
+
+USAGE:
+    erg [OPTIONS] [SUBCOMMAND] [ARGS]...
+
+    For more information try `erg --help`"
                     );
                     process::exit(0);
                 }

--- a/compiler/erg_common/config.rs
+++ b/compiler/erg_common/config.rs
@@ -393,7 +393,7 @@ USAGE:
 
     For more information try `erg --help`"
                     );
-                    process::exit(0);
+                    process::exit(2);
                 }
                 _ => {
                     cfg.input = Input::File(


### PR DESCRIPTION
In Erg, it caused panic when there was an invalid argument.
However, in other languages, instead of panicking, indicate that it is an invalid argument and have them refer to help.
Added a message to that effect.

Changes proposed in this PR:
- avoid panicking

@mtshiba
