### PR TITLE
Fix and clean lex Str and MultilineStr

### DIFF
--- a/compiler/erg_parser/lex.rs
+++ b/compiler/erg_parser/lex.rs
@@ -787,8 +787,9 @@ impl Lexer /*<'a>*/ {
         Err(Self::unclosed_string_error(token, "\"", line!() as usize))
     }
 
+    const QUOTES: &str = "\"\"\"";
     fn lex_multi_line_str(&mut self) -> LexResult<Token> {
-        let mut s = "\"\"\"".to_string();
+        let mut s = Self::QUOTES.to_string();
         while let Some(c) = self.peek_cur_ch() {
             if c == '"' {
                 let c = self.consume().unwrap();
@@ -798,7 +799,7 @@ impl Lexer /*<'a>*/ {
                     let token = self.emit_token(Illegal, &s);
                     return Err(Self::unclosed_string_error(
                         token,
-                        "\"\"\"",
+                        Self::QUOTES,
                         line!() as usize,
                     ));
                 }
@@ -807,14 +808,14 @@ impl Lexer /*<'a>*/ {
                     let token = self.emit_token(Illegal, &s);
                     return Err(Self::unclosed_string_error(
                         token,
-                        "\"\"\"",
+                        Self::QUOTES,
                         line!() as usize,
                     ));
                 }
                 if next_c.unwrap() == '"' && aft_next_c.unwrap() == '"' {
                     self.consume().unwrap();
                     self.consume().unwrap();
-                    s.push_str("\"\"\"");
+                    s.push_str(Self::QUOTES);
                     let token = self.emit_token(StrLit, &s);
                     return Ok(token);
                 }
@@ -868,7 +869,7 @@ impl Lexer /*<'a>*/ {
         if self.interpol_stack.len() == 1 {
             Err(Self::unclosed_string_error(
                 token,
-                "\"\"\"",
+                Self::QUOTES,
                 line!() as usize,
             ))
         } else {
@@ -913,7 +914,7 @@ impl Lexer /*<'a>*/ {
                                 let token = self.emit_token(Illegal, &s);
                                 return Err(Self::unclosed_string_error(
                                     token,
-                                    "\"\"\"",
+                                    Self::QUOTES,
                                     line!() as usize,
                                 ));
                             }
@@ -923,7 +924,7 @@ impl Lexer /*<'a>*/ {
                                 let token = self.emit_token(Illegal, &s);
                                 return Err(Self::unclosed_string_error(
                                     token,
-                                    "\"\"\"",
+                                    Self::QUOTES,
                                     line!() as usize,
                                 ));
                             }
@@ -931,7 +932,7 @@ impl Lexer /*<'a>*/ {
                                 self.interpol_stack.pop();
                                 self.consume().unwrap();
                                 self.consume().unwrap();
-                                s.push_str("\"\"\"");
+                                s.push_str(Self::QUOTES);
                                 let token = self.emit_token(StrInterpRight, &s);
                                 return Ok(token);
                             }

--- a/compiler/erg_parser/lex.rs
+++ b/compiler/erg_parser/lex.rs
@@ -699,10 +699,10 @@ impl Lexer /*<'a>*/ {
             "".to_string()
         } else {
             switch_lang!(
-                "japanese" => format!("\"\"\"によって"),
-                "simplified_chinese" => format!("\"\"\"关"),
-                "traditional_chinese" => format!("\"\"\"关"),
-                "english" => format!("by \"\"\""),
+                "japanese" => format!("{by}によって"),
+                "simplified_chinese" => format!("{by}关"),
+                "traditional_chinese" => format!("{by}关"),
+                "english" => format!("by {by}"),
             )
         };
         LexError::syntax_error(
@@ -727,6 +727,21 @@ impl Lexer /*<'a>*/ {
                 "simplified_chinese" => "字符串内的插值没有被闭",
                 "traditional_chinese" => "字符串內的插值沒有被閉",
                 "english" => "the interpolation in the string is not closed",
+            ),
+            None,
+        )
+    }
+
+    fn invalid_unicode_character(&mut self, s: &str) -> LexError {
+        let token = self.emit_token(Illegal, s);
+        LexError::syntax_error(
+            0,
+            token.loc(),
+            switch_lang!(
+                "japanese" => "不正なユニコード文字(双方向オーバーライド)が文字列中に使用されています",
+                "simplified_chinese" => "注释中使用了非法的unicode字符（双向覆盖）",
+                "traditional_chinese" => "註釋中使用了非法的unicode字符（雙向覆蓋）",
+                "english" => "invalid unicode character (bi-directional override) in string literal",
             ),
             None,
         )
@@ -777,7 +792,7 @@ impl Lexer /*<'a>*/ {
                     } else {
                         s.push(c);
                         if Self::is_bidi(c) {
-                            return Err(self._invalid_unicode_character(&s));
+                            return Err(self.invalid_unicode_character(&s));
                         }
                     }
                 }
@@ -859,7 +874,7 @@ impl Lexer /*<'a>*/ {
                     _ => {
                         s.push(c);
                         if Self::is_bidi(c) {
-                            return Err(self._invalid_unicode_character(&s));
+                            return Err(self.invalid_unicode_character(&s));
                         }
                     }
                 }
@@ -971,7 +986,7 @@ impl Lexer /*<'a>*/ {
                     } else {
                         s.push(c);
                         if Self::is_bidi(c) {
-                            return Err(self._invalid_unicode_character(&s));
+                            return Err(self.invalid_unicode_character(&s));
                         }
                     }
                 }
@@ -1001,7 +1016,7 @@ impl Lexer /*<'a>*/ {
                     let c = self.consume().unwrap();
                     s.push(c);
                     if Self::is_bidi(c) {
-                        return Err(self._invalid_unicode_character(&s));
+                        return Err(self.invalid_unicode_character(&s));
                     }
                 }
             }
@@ -1018,22 +1033,6 @@ impl Lexer /*<'a>*/ {
             ),
             None,
         ))
-    }
-
-    // for single strings and multi-line strings
-    fn _invalid_unicode_character(&mut self, s: &str) -> LexError {
-        let token = self.emit_token(Illegal, s);
-        LexError::syntax_error(
-            0,
-            token.loc(),
-            switch_lang!(
-                "japanese" => "不正なユニコード文字(双方向オーバーライド)が文字列中に使用されています",
-                "simplified_chinese" => "注释中使用了非法的unicode字符（双向覆盖）",
-                "traditional_chinese" => "註釋中使用了非法的unicode字符（雙向覆蓋）",
-                "english" => "invalid unicode character (bi-directional override) in string literal",
-            ),
-            None,
-        )
     }
 }
 


### PR DESCRIPTION


Changes proposed in this PR:
- `by: &str` was not used in unclosed_string_error()

- A lot of \\"\\"\\" was used, so I fixed it to const

- Placed invalid_unicode_character location below other error location

@mtshiba
