### PR TITLE
remove: duplicates

### DIFF
--- a/compiler/erg_common/style.rs
+++ b/compiler/erg_common/style.rs
@@ -162,26 +162,12 @@ impl Characters {
         (self.vbreak, self.vbar)
     }
 
-    // "`- "
-    #[cfg(not(feature = "unicode"))]
+    // "`- " or `╰─ `
     pub fn left_bottom_line(&self) -> String {
         format!("{}{} ", self.lbot, self.line)
     }
 
-    // `╰─ `
-    #[cfg(feature = "unicode")]
-    pub fn left_bottom_line(&self) -> String {
-        format!("{}{} ", self.lbot, self.line)
-    }
-
-    // "|- "
-    #[cfg(not(feature = "unicode"))]
-    pub fn left_cross(&self) -> String {
-        format!("{}{} ", self.vbar, self.line)
-    }
-
-    // "│─ "
-    #[cfg(feature = "unicode")]
+    // "|- " or "│─ "
     pub fn left_cross(&self) -> String {
         format!("{}{} ", self.vbar, self.line)
     }


### PR DESCRIPTION
There used to be a space before the apostrophe, but that has now been removed.

Therefore, it is a Duplicate and has been removed.