### PR TITLE
Fix syntax is ignore after multi-line comment

### DIFF
--- a/compiler/erg_parser/lex.rs
+++ b/compiler/erg_parser/lex.rs
@@ -323,6 +323,8 @@ impl Lexer /*<'a>*/ {
                     (']', '#') => {
                         nest_level -= 1;
                         if nest_level == 0 {
+                            self.consume(); // ]
+                            self.consume(); // #
                             return Ok(());
                         }
                     }
@@ -448,8 +450,11 @@ impl Lexer /*<'a>*/ {
                 if let Err(e) = self.lex_multi_line_comment() {
                     return Some(Err(e));
                 }
-            }
-            if let Err(e) = self.lex_comment() {
+                let indent_dedent = self.lex_space_indent_dedent();
+                if indent_dedent.is_some() {
+                    return indent_dedent;
+                }
+            } else if let Err(e) = self.lex_comment() {
                 return Some(Err(e));
             }
         }
@@ -1059,8 +1064,11 @@ impl Iterator for Lexer /*<'a>*/ {
                 if let Err(e) = self.lex_multi_line_comment() {
                     return Some(Err(e));
                 }
-            }
-            if let Err(e) = self.lex_comment() {
+                let indent_dedent = self.lex_space_indent_dedent();
+                if indent_dedent.is_some() {
+                    return indent_dedent;
+                }
+            } else if let Err(e) = self.lex_comment() {
                 return Some(Err(e));
             }
         }

--- a/compiler/erg_parser/lex.rs
+++ b/compiler/erg_parser/lex.rs
@@ -450,10 +450,6 @@ impl Lexer /*<'a>*/ {
                 if let Err(e) = self.lex_multi_line_comment() {
                     return Some(Err(e));
                 }
-                let indent_dedent = self.lex_space_indent_dedent();
-                if indent_dedent.is_some() {
-                    return indent_dedent;
-                }
             } else if let Err(e) = self.lex_comment() {
                 return Some(Err(e));
             }
@@ -1063,10 +1059,6 @@ impl Iterator for Lexer /*<'a>*/ {
             if let Some('[') = self.peek_next_ch() {
                 if let Err(e) = self.lex_multi_line_comment() {
                     return Some(Err(e));
-                }
-                let indent_dedent = self.lex_space_indent_dedent();
-                if indent_dedent.is_some() {
-                    return indent_dedent;
                 }
             } else if let Err(e) = self.lex_comment() {
                 return Some(Err(e));

--- a/tests/should_ok/comment.er
+++ b/tests/should_ok/comment.er
@@ -1,7 +1,11 @@
 #[]#print! "hi"#[ if there isn't `;`, this code is evaluated `print! "hi"h print! "there"`
 ]#;print! "there"
-print! #[]#0, 1#[]#, 2,#[]# 3
+print! #[]#0, 1#[]#, 2,#[]#3
 a = {
-#[first]#    #[second]#name #[third]#=#[fourth]#"John"#[fifth]#
+    #[first]#name #[second]#=#[third]#"John"#[fouth]#
 }
 Del a
+#[]#print! 0
+print!#[]#1
+#[]#print! 2#[
+]#

--- a/tests/should_ok/comment.er
+++ b/tests/should_ok/comment.er
@@ -1,0 +1,7 @@
+#[]#print! "hi"#[ if there isn't `;`, this code is evaluated `print! "hi"h print! "there"`
+]#;print! "there"
+print! #[]#0, 1#[]#, 2,#[]# 3
+a = {
+#[first]#    #[second]#name #[third]#=#[fourth]#"John"#[fifth]#
+}
+Del a

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -224,3 +224,8 @@ fn exec_callable() -> Result<(), ()> {
 fn exec_multiline_invalid_next() -> Result<(), ()> {
     expect_failure("tests/should_err/multi_line_invalid_nest.er", 1)
 }
+
+#[test]
+fn exec_comment() -> Result<(), ()> {
+    expect_success("tests/should_ok/comment.er")
+}


### PR DESCRIPTION
Fixes #311.

A one-line comment was executed after a multi-line comment.
That's why, syntax after multi-line comments was ignored.

~~There may also be a whitespace after the multi-line comment.~~
~~This could be invalid, please check.~~

```python
a =
#[comment]#    1#Is this valid?
```
I made it syntax error.

Changes proposed in this PR:
- Fix syntax is ignore after multi-line comment

@mtshiba
