### PR TITLE
CI: Run build-check and lint in parallel

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
         # HACK: The cause is unknown, but on windows, the exit code is 1 even if tests are successful.
         run: cargo test --features large_thread --features pre-commit --all --verbose
       - name: Run tests (Other OS)
-        if: matrix.os != 'Windows'
+        if: runner.os != 'Windows'
         run: cargo test --features large_thread --all --verbose
 
   build-check:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,32 +22,37 @@ jobs:
         with:
           python-version: "3.11.0"
       - uses: Swatinem/rust-cache@v2
-      - name: Build
-        run: |
-          rustup update stable
-          cargo build --verbose
-      - name: Run tests
-        run: cargo test --features large_thread --verbose --all
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
-  test-win:
-    runs-on: windows-latest
+      - run: rustup update stable
+      - name: Compile
+        run: cargo test --features large_thread --all --verbose --no-run
+      - name: Run tests (Windows)
+        if: runner.os == 'Windows'
+        # HACK: The cause is unknown, but on windows, the exit code is 1 even if tests are successful.
+        run: cargo test --features large_thread --features pre-commit --all --verbose
+      - name: Run tests (Other OS)
+        if: matrix.os != 'Windows'
+        run: cargo test --features large_thread --all --verbose
+
+  build-check:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.11.0"
       - uses: Swatinem/rust-cache@v2
-      - name: Build
-        run: |
-          rustup update stable
-          cargo build --verbose
-      - name: Run tests
-        # HACK: The cause is unknown, but on windows, the exit code is 1 even if tests are successful.
-        run: cargo test --features large_thread --features pre-commit --verbose --all
-      - uses: actions-rs/cargo@v1
+      - run: rustup update stable
+      - run: cargo build --all --all-targets --verbose --release
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v2
+      - run: rustup update stable
+      - name: cargo clippy
+        uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all --all-targets --verbose -- -D warnings


### PR DESCRIPTION
Running CI in parallel makes it faster and easier to see.
Separated build check and lint and changed a few options.

@mtshiba
