### PR TITLE
Change data structure from `Vec` to `VecDeque`

### DIFF
--- a/compiler/els/util.rs
+++ b/compiler/els/util.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io::Read;
 
-use erg_common::traits::{Locational, Stream};
+use erg_common::traits::{DequeStream, Locational};
 
 use erg_compiler::erg_parser::lex::Lexer;
 use erg_compiler::erg_parser::token::{Token, TokenKind};

--- a/compiler/erg_common/traits.rs
+++ b/compiler/erg_common/traits.rs
@@ -1,6 +1,8 @@
 //! defines common traits used in the compiler.
 //!
 //! コンパイラ等で汎用的に使われるトレイトを定義する
+use std::collections::vec_deque;
+use std::collections::VecDeque;
 use std::env::consts::{ARCH, OS};
 use std::io::{stdout, BufWriter, Write};
 use std::mem;
@@ -11,6 +13,128 @@ use crate::config::{ErgConfig, Input};
 use crate::consts::{BUILD_DATE, GIT_HASH_SHORT, SEMVER};
 use crate::error::{ErrorDisplay, ErrorKind, Location, MultiErrorDisplay};
 use crate::{addr_eq, chomp, log, switch_unreachable};
+
+pub trait DequeStream<T>: Sized {
+    fn payload(self) -> VecDeque<T>;
+    fn ref_payload(&self) -> &VecDeque<T>;
+    fn ref_mut_payload(&mut self) -> &mut VecDeque<T>;
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.ref_payload().is_empty()
+    }
+
+    #[inline]
+    fn insert(&mut self, idx: usize, elem: T) {
+        self.ref_mut_payload().insert(idx, elem);
+    }
+
+    #[inline]
+    fn push(&mut self, elem: T) {
+        self.ref_mut_payload().push_back(elem);
+    }
+
+    fn pop_front(&mut self) -> Option<T> {
+        self.ref_mut_payload().pop_front()
+    }
+
+    #[inline]
+    fn get(&self, idx: usize) -> Option<&T> {
+        self.ref_payload().get(idx)
+    }
+
+    #[inline]
+    fn first(&self) -> Option<&T> {
+        self.ref_payload().front()
+    }
+
+    #[inline]
+    fn last(&self) -> Option<&T> {
+        self.ref_payload().back()
+    }
+
+    #[inline]
+    fn iter(&self) -> vec_deque::Iter<'_, T> {
+        self.ref_payload().iter()
+    }
+}
+
+#[macro_export]
+macro_rules! impl_displayable_deque_stream_for_wrapper {
+    ($Strc: ident, $Inner: ident) => {
+        impl $Strc {
+            pub const fn new(v: VecDeque<$Inner>) -> $Strc {
+                $Strc(v)
+            }
+            pub fn empty() -> $Strc {
+                $Strc(VecDeque::new())
+            }
+            #[inline]
+            pub fn with_capacity(capacity: usize) -> $Strc {
+                $Strc(VecDeque::with_capacity(capacity))
+            }
+        }
+
+        impl Default for $Strc {
+            #[inline]
+            fn default() -> $Strc {
+                $Strc::with_capacity(0)
+            }
+        }
+
+        impl std::ops::Index<usize> for $Strc {
+            type Output = $Inner;
+            fn index(&self, idx: usize) -> &Self::Output {
+                erg_common::traits::DequeStream::get(self, idx).unwrap()
+            }
+        }
+
+        impl From<$Strc> for VecDeque<$Inner> {
+            fn from(item: $Strc) -> VecDeque<$Inner> {
+                item.payload()
+            }
+        }
+
+        impl std::fmt::Display for $Strc {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> fmt::Result {
+                write!(
+                    f,
+                    "[{}]",
+                    erg_common::fmt_iter(self.iter()).replace("\n", "\\n")
+                )
+            }
+        }
+
+        impl IntoIterator for $Strc {
+            type Item = $Inner;
+            type IntoIter = std::collections::vec_deque::IntoIter<Self::Item>;
+            fn into_iter(self) -> Self::IntoIter {
+                self.payload().into_iter()
+            }
+        }
+
+        impl FromIterator<$Inner> for $Strc {
+            fn from_iter<I: IntoIterator<Item = $Inner>>(iter: I) -> Self {
+                $Strc(iter.into_iter().collect())
+            }
+        }
+
+        impl $crate::traits::DequeStream<$Inner> for $Strc {
+            #[inline]
+            fn payload(self) -> VecDeque<$Inner> {
+                self.0
+            }
+            #[inline]
+            fn ref_payload(&self) -> &VecDeque<$Inner> {
+                &self.0
+            }
+            #[inline]
+            fn ref_mut_payload(&mut self) -> &mut VecDeque<$Inner> {
+                &mut self.0
+            }
+        }
+    };
+}
 
 pub trait Stream<T>: Sized {
     fn payload(self) -> Vec<T>;

--- a/compiler/erg_parser/lex.rs
+++ b/compiler/erg_parser/lex.rs
@@ -6,6 +6,7 @@ use unicode_xid::UnicodeXID;
 use erg_common::cache::CacheSet;
 use erg_common::config::ErgConfig;
 use erg_common::config::Input;
+use erg_common::traits::DequeStream;
 use erg_common::traits::{Locational, Runnable, Stream};
 use erg_common::{debug_power_assert, fn_name_full, normalize_newline, switch_lang};
 

--- a/compiler/erg_parser/parse.rs
+++ b/compiler/erg_parser/parse.rs
@@ -11,6 +11,7 @@ use erg_common::error::Location;
 use erg_common::option_enum_unwrap;
 use erg_common::set::Set as HashSet;
 use erg_common::str::Str;
+use erg_common::traits::DequeStream;
 use erg_common::traits::Runnable;
 use erg_common::traits::{Locational, Stream};
 use erg_common::{
@@ -96,8 +97,8 @@ impl Parser {
     }
 
     #[inline]
-    pub(crate) fn peek(&self) -> Option<&Token> {
-        self.tokens.get(0)
+    pub fn peek(&self) -> Option<&Token> {
+        self.tokens.first()
     }
 
     #[inline]
@@ -107,12 +108,12 @@ impl Parser {
 
     #[inline]
     fn skip(&mut self) {
-        self.tokens.remove(0);
+        self.tokens.pop_front();
     }
 
     #[inline]
     fn lpop(&mut self) -> Token {
-        self.tokens.remove(0)
+        self.tokens.pop_front().unwrap()
     }
 
     fn cur_category_is(&self, category: TokenCategory) -> bool {

--- a/compiler/erg_parser/token.rs
+++ b/compiler/erg_parser/token.rs
@@ -1,14 +1,15 @@
 //! defines `Token` (The minimum unit in the Erg source code that serves as input to the parser).
 //!
 //! Token(パーサーへの入力となる、Ergソースコードにおける最小単位)を定義する
+use std::collections::VecDeque;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
 use erg_common::error::Location;
-use erg_common::impl_displayable_stream_for_wrapper;
+use erg_common::impl_displayable_deque_stream_for_wrapper;
 use erg_common::opcode311::BinOpCode;
 use erg_common::str::Str;
-use erg_common::traits::{Locational, Stream};
+use erg_common::traits::{DequeStream, Locational};
 // use erg_common::ty::Type;
 // use erg_common::typaram::OpKind;
 // use erg_common::value::ValueObj;
@@ -474,6 +475,6 @@ impl Token {
 }
 
 #[derive(Debug, Clone)]
-pub struct TokenStream(Vec<Token>);
+pub struct TokenStream(VecDeque<Token>);
 
-impl_displayable_stream_for_wrapper!(TokenStream, Token);
+impl_displayable_deque_stream_for_wrapper!(TokenStream, Token);


### PR DESCRIPTION
Fixes #292 .

`Stream` uses `Vec`, but, using insert(0), remove(0) in this case, it takes O(n) for this process alone every time

In such cases, it is better to use `VecDeque`, so as for `TokenStream`, use the `Stream` implemented by `VecDeque`

Changes proposed in this PR:
- Change Vec to VecDeque
- Implement Stream with VecDeque
- TokenStream use VecDeque

@mtshiba
