### PR TITLE
CI: If only doc/ is changed, do not run CI for rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,12 @@ name: Rust
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "doc/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "doc/**"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Since the `doc/` directory is updated frequently, I tried to make them ignore useless CIs

@mtshiba
