### PR TITLE
Change insert(0, elem) to push_front(elem)

### DIFF
--- a/compiler/erg_common/traits.rs
+++ b/compiler/erg_common/traits.rs
@@ -25,13 +25,13 @@ pub trait DequeStream<T>: Sized {
     }
 
     #[inline]
-    fn insert(&mut self, idx: usize, elem: T) {
-        self.ref_mut_payload().insert(idx, elem);
+    fn push(&mut self, elem: T) {
+        self.ref_mut_payload().push_back(elem);
     }
 
     #[inline]
-    fn push(&mut self, elem: T) {
-        self.ref_mut_payload().push_back(elem);
+    fn push_front(&mut self, elem: T) {
+        self.ref_mut_payload().push_front(elem);
     }
 
     fn pop_front(&mut self) -> Option<T> {

--- a/compiler/erg_parser/parse.rs
+++ b/compiler/erg_parser/parse.rs
@@ -183,7 +183,7 @@ impl Parser {
 
     #[inline]
     fn restore(&mut self, token: Token) {
-        self.tokens.insert(0, token);
+        self.tokens.push_front(token);
     }
 
     pub(crate) fn stack_dec(&mut self) {


### PR DESCRIPTION
In parse.rs, `self.restore(elem)` use `insert(0, elme)` internally.
This has an O(n) calc cost for each time this is used
VecDeque has a `push_front` method, which is used