### PR TITLE
Remove duplicate error indicate

### DIFF
--- a/compiler/erg_parser/tests/parse_test.rs
+++ b/compiler/erg_parser/tests/parse_test.rs
@@ -107,7 +107,6 @@ fn expect_failure(file_path: &'static str, errs_len: usize) -> Result<(), ()> {
     match parse_test_from_code(file_path) {
         Ok(_) => Err(()),
         Err(errs) => {
-            errs.fmt_all_stderr();
             if errs.len() == errs_len {
                 Ok(())
             } else {


### PR DESCRIPTION
Errors are shown on `_parse_test_from_code()`
Not required in this part