### PR TITLE
Use debug_exit_info!() before exit a current method

### DIFF
--- a/compiler/erg_parser/parse.rs
+++ b/compiler/erg_parser/parse.rs
@@ -43,6 +43,7 @@ macro_rules! debug_call_info {
     };
 }
 
+#[macro_export]
 macro_rules! debug_exit_info {
     ($self: ident) => {
         $self.level -= 1;


### PR DESCRIPTION
I forgot to replace "self.level -= 1" to "debug_exit_info!()"
Also, put macro before exiting a current method