### PR TITLE
Fixes #344

### DIFF
--- a/crates/erg_common/traits.rs
+++ b/crates/erg_common/traits.rs
@@ -527,10 +527,18 @@ pub trait Runnable: Sized + Default {
         self.cfg_mut().input = input;
     }
     fn start_message(&self) -> String {
-        format!(
-            "{} {SEMVER} ({GIT_HASH_SHORT}, {BUILD_DATE}) on {ARCH}/{OS}\n",
-            Self::NAME
-        )
+        if GIT_HASH_SHORT.is_empty() {
+            format!(
+                "{} {SEMVER} ({BUILD_DATE}) on {ARCH}/{OS}\n",
+                Self::NAME
+            )
+        } else {
+            format!(
+                "{} {SEMVER} ({GIT_HASH_SHORT}, {BUILD_DATE}) on {ARCH}/{OS}\n",
+                Self::NAME
+            )
+        }
+        
     }
     fn ps1(&self) -> String {
         self.cfg().ps1.to_string()


### PR DESCRIPTION
Fixes #344.

I  think that installing from cargo means that git hash is no longer needed as an identifier(Because there is a specific version as an identifier), so #344 can be solved easily

@mtshiba
