### PR TITLE
add feature: `no_std`

### DIFF
--- a/crates/erg_common/Cargo.toml
+++ b/crates/erg_common/Cargo.toml
@@ -19,6 +19,7 @@ pretty = []
 large_thread = []
 els = []
 py_compatible = []
+no_std = []
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", default-features = false }

--- a/crates/erg_common/env.rs
+++ b/crates/erg_common/env.rs
@@ -1,13 +1,12 @@
-use std::env::var;
 use std::path::PathBuf;
 
 use crate::normalize_path;
 
 fn _erg_path() -> PathBuf {
     #[cfg(feature = "no_std")]
-    let path = "".to_string("./");
+    let path = "./".to_string();
     #[cfg(not(feature = "no_std"))]
-    let path = var("ERG_PATH").unwrap_or_else(|_| env!("CARGO_ERG_PATH").to_string());
+    let path = std::env::var("ERG_PATH").unwrap_or_else(|_| env!("CARGO_ERG_PATH").to_string());
     PathBuf::from(path)
         .canonicalize()
         .expect("ERG_PATH not found")

--- a/crates/erg_common/env.rs
+++ b/crates/erg_common/env.rs
@@ -1,12 +1,10 @@
+use std::env::var;
 use std::path::PathBuf;
 
 use crate::normalize_path;
 
 fn _erg_path() -> PathBuf {
-    #[cfg(feature = "no_std")]
-    let path = "./".to_string();
-    #[cfg(not(feature = "no_std"))]
-    let path = std::env::var("ERG_PATH").unwrap_or_else(|_| env!("CARGO_ERG_PATH").to_string());
+    let path = var("ERG_PATH").unwrap_or_else(|_| env!("CARGO_ERG_PATH").to_string());
     PathBuf::from(path)
         .canonicalize()
         .expect("ERG_PATH not found")

--- a/crates/erg_common/env.rs
+++ b/crates/erg_common/env.rs
@@ -4,6 +4,9 @@ use std::path::PathBuf;
 use crate::normalize_path;
 
 fn _erg_path() -> PathBuf {
+    #[cfg(feature = "no_std")]
+    let path = "".to_string("./");
+    #[cfg(not(feature = "no_std"))]
     let path = var("ERG_PATH").unwrap_or_else(|_| env!("CARGO_ERG_PATH").to_string());
     PathBuf::from(path)
         .canonicalize()

--- a/crates/erg_compiler/Cargo.toml
+++ b/crates/erg_compiler/Cargo.toml
@@ -36,6 +36,7 @@ large_thread = [
 ]
 py_compatible = ["erg_common/py_compatible"]
 els = ["erg_common/els"]
+no_std = ["erg_common/no_std"]
 
 [dependencies]
 erg_common = { workspace = true, path = "../erg_common" }

--- a/crates/erg_compiler/context/initialize/mod.rs
+++ b/crates/erg_compiler/context/initialize/mod.rs
@@ -306,8 +306,13 @@ const KW_ITERABLE: &str = "iterable";
 const KW_INDEX: &str = "index";
 const KW_KEY: &str = "key";
 
+#[cfg(not(feature = "no_std"))]
 pub fn builtins_path() -> PathBuf {
     erg_pystd_path().join("builtins.d.er")
+}
+#[cfg(feature = "no_std")]
+pub fn builtins_path() -> PathBuf {
+    PathBuf::from("lib/pystd/builtins.d.er")
 }
 
 impl Context {


### PR DESCRIPTION
Solves the problem of web-ide freezing: since web-ide does not have access to local files, it turns on this feature and simply ignores such requests.
