### PR TITLE
Complete grammar on visibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ homepage = "https://erg-lang.org/"
 
 [features]
 # when "debug" feature is turned on, that of the following crates will also be turned on.
-debug = ["erg_common/debug", "erg_parser/debug", "erg_compiler/debug", "els/debug"]
+debug = ["erg_common/debug", "erg_parser/debug", "erg_compiler/debug"]
 japanese = [
     "erg_common/japanese",
     "erg_parser/japanese",
@@ -59,6 +59,7 @@ large_thread = [
 ]
 py_compatible = ["erg_compiler/py_compatible", "els/py_compatible"]
 els = ["erg_common/els", "erg_compiler/els", "dep:els"]
+els-debug = ["debug", "els/debug"]
 full-repl = ["erg_common/full-repl"]
 full = ["els", "full-repl", "unicode", "pretty"]
 

--- a/crates/erg_common/str.rs
+++ b/crates/erg_common/str.rs
@@ -14,6 +14,12 @@ pub enum Str {
     Static(&'static str),
 }
 
+impl Default for Str {
+    fn default() -> Self {
+        Str::ever("")
+    }
+}
+
 impl PartialEq for Str {
     #[inline]
     fn eq(&self, other: &Str) -> bool {

--- a/crates/erg_common/vis.rs
+++ b/crates/erg_common/vis.rs
@@ -78,4 +78,8 @@ impl Field {
     pub fn is_const(&self) -> bool {
         self.symbol.starts_with(char::is_uppercase)
     }
+
+    pub const fn vis(&self) -> Visibility {
+        self.vis
+    }
 }

--- a/crates/erg_compiler/context/initialize/mod.rs
+++ b/crates/erg_compiler/context/initialize/mod.rs
@@ -585,7 +585,7 @@ impl Context {
         };
         let muty = Immutable;
         let loc = Location::range(lineno, 0, lineno, name.inspect().len() as u32);
-        let abs_loc = AbsLocation::new(Some(builtins_path()), loc);
+        let abs_loc = AbsLocation::new(Some(builtins_path()), loc, "<builtins>".into());
         self.register_builtin_impl(name, t, muty, vis, py_name, abs_loc);
     }
 

--- a/crates/erg_compiler/context/mod.rs
+++ b/crates/erg_compiler/context/mod.rs
@@ -470,11 +470,11 @@ impl Context {
         let mut params_ = Vec::new();
         for param in params.into_iter() {
             let id = DefId(get_hash(&(&name, &param)));
-            if let Some(name) = param.name {
+            if let Some(p_name) = param.name {
                 let kind = VarKind::parameter(id, param.default_info);
-                let muty = Mutability::from(name);
+                let muty = Mutability::from(p_name);
                 let vi = VarInfo::new(param.t, muty, Private, kind, None, None, None, param.loc);
-                params_.push((Some(VarName::new(Token::static_symbol(name))), vi));
+                params_.push((Some(VarName::new(Token::static_symbol(p_name))), vi));
             } else {
                 let kind = VarKind::parameter(id, param.default_info);
                 let muty = Mutability::Immutable;
@@ -813,7 +813,7 @@ impl Context {
     }
 
     pub(crate) fn absolutize(&self, loc: Location) -> AbsLocation {
-        AbsLocation::new(self.module_path().cloned(), loc)
+        AbsLocation::new(self.module_path().cloned(), loc, self.name.clone())
     }
 
     #[inline]
@@ -928,6 +928,10 @@ impl Context {
             // toplevel
             Some(mem::take(self))
         }
+    }
+
+    pub fn is_sub_namespace(&self, namespace: &str) -> bool {
+        self.name.starts_with(namespace)
     }
 
     pub(crate) fn check_decls_and_pop(&mut self) -> Result<Context, TyCheckErrors> {

--- a/crates/erg_parser/desugar.rs
+++ b/crates/erg_parser/desugar.rs
@@ -620,7 +620,10 @@ impl Desugarer {
                     r_brace,
                 )
             }
-            BufIndex::Record(attr) => obj.attr(attr.clone()),
+            BufIndex::Record(attr) => obj.attr(Identifier::new(
+                Some(attr.name.token().clone()),
+                attr.name.clone(),
+            )),
         };
         let id = DefId(get_hash(&(&acc, buf_name)));
         let block = Block::new(vec![Expr::Accessor(acc)]);

--- a/examples/class.er
+++ b/examples/class.er
@@ -4,12 +4,12 @@ print! empty
 
 # Inheritance is prohibited by default. Remove this decorator and check for errors.
 @Inheritable
-Point2D = Class {x = Int; y = Int}
+Point2D = Class {.x = Int; .y = Int}
 Point2D::
     one = 1
 Point2D.
     zero = Point2D::one - 1
-    norm self = self::x**2 + self::y**2
+    norm self = self.x**2 + self.y**2
 
 Point3D = Inherit Point2D, Additional := {z = Int}
 Point3D.
@@ -18,7 +18,7 @@ Point3D.
     new x, y, z =
         Point3D::__new__ {x; y; z}
     @Override
-    norm self = self::x**2 + self::y**2 + self::z**2
+    norm self = self.x**2 + self.y**2 + self::z**2
 
 # `Point2D::__new__` is private, use `Point2D.new` instead
 p = Point2D.new {x = 1; y = 2}

--- a/examples/unpack.er
+++ b/examples/unpack.er
@@ -1,5 +1,5 @@
-UnpackPoint2D = Class {x = Int; y = Int}, Impl := Unpack
+UnpackPoint2D = Class {.x = Int; .y = Int}, Impl := Unpack
 
-q = UnpackPoint2D::{x = 1; y = 2}
+q = UnpackPoint2D::{.x = 1; .y = 2}
 UnpackPoint2D::{x; y} = q
 print! x, y

--- a/tests/repl.rs
+++ b/tests/repl.rs
@@ -106,7 +106,7 @@ fn exec_invalid_class_inheritable() -> Result<(), ()> {
         "repl_auto_indent_dedent",
         [
             "@Inheritable",
-            "Point2d = Class{ x = Int; y = Int }",
+            "Point2d = Class{ .x = Int; .y = Int }",
             "Point2d::",
             "one = 1",
             "",
@@ -119,7 +119,7 @@ fn exec_invalid_class_inheritable() -> Result<(), ()> {
             "new(x, y, z) =",
             "Point3d::__new__{x; y; z}",
             "",
-            "norm self = self::x**2 + self::y**2 + self::z**2",
+            "norm self = self.x**2 + self.y**2 + self::z**2",
             "",
             "p = Point3d.new 1, 2, 3",
             "print! p.norm()",


### PR DESCRIPTION
Resolve #240 and also add [restricted variable syntax](https://github.com/erg-lang/erg/blob/6fb51676c9b90b50207dbf4d971e88ae0dd2a8e5/doc/EN/syntax/20_visibility.md#restrictedpublicvariables). This PR contains a destructive change because it prevents subclasses from accessing private variables in super classes.

However, finally, the example code change will not occur by introducing restricted variable syntax.
