### PR TITLE
feat: check doc comments by the compiler

### DIFF
--- a/crates/erg_common/lib.rs
+++ b/crates/erg_common/lib.rs
@@ -178,9 +178,9 @@ pub fn trim_eliminate_top_indent(code: String) -> String {
     let mut result = String::new();
     for line in code.lines() {
         if line.len() > indent {
-            result.push_str(&line[indent..]);
+            result.push_str(line[indent..].trim_end());
         } else {
-            result.push_str(line);
+            result.push_str(line.trim_end());
         }
         result.push('\n');
     }

--- a/crates/erg_compiler/lower.rs
+++ b/crates/erg_compiler/lower.rs
@@ -2415,7 +2415,7 @@ impl ASTLowerer {
     /// The meaning of TypeAscription changes between chunk and expr.
     /// For example, `x: Int`, as expr, is `x` itself,
     /// but as chunk, it declares that `x` is of type `Int`, and is valid even before `x` is defined.
-    fn lower_chunk(&mut self, chunk: ast::Expr) -> LowerResult<hir::Expr> {
+    pub(crate) fn lower_chunk(&mut self, chunk: ast::Expr) -> LowerResult<hir::Expr> {
         log!(info "entered {}", fn_name!());
         match chunk {
             ast::Expr::Def(def) => Ok(hir::Expr::Def(self.lower_def(def)?)),
@@ -2521,6 +2521,7 @@ impl ASTLowerer {
         };
         self.warn_unused_expr(&hir.module, mode);
         self.warn_unused_vars(mode);
+        self.check_doc_comments(&hir);
         if self.errs.is_empty() {
             log!(info "the AST lowering process has completed.");
             Ok(CompleteArtifact::new(

--- a/examples/class.er
+++ b/examples/class.er
@@ -9,6 +9,10 @@ Point2D::
     one = 1
 Point2D.
     zero = Point2D::one - 1
+    '''erg
+    p = Point2D.new {x = 1; y = 2}
+    assert p.norm() == 5
+    '''
     norm self = self::x**2 + self::y**2
 
 Point3D = Inherit Point2D, Additional := {z = Int}


### PR DESCRIPTION
With this PR, the compiler will now perform checks on doc-comments. If a compile error occurs within a doc-comment, the code cannot be executed.