### PR TITLE
fix(repl): fix repl server crash when meet a exception

### DIFF
--- a/crates/erg_compiler/codegen.rs
+++ b/crates/erg_compiler/codegen.rs
@@ -187,6 +187,17 @@ impl PyCodeGenerator {
         self.units.clear();
     }
 
+    pub fn initialize(&mut self) {
+        self.prelude_loaded = false;
+        self.mutate_op_loaded = false;
+        self.in_op_loaded = false;
+        self.record_type_loaded = false;
+        self.module_type_loaded = false;
+        self.control_loaded = false;
+        self.convertors_loaded = false;
+        self.abc_loaded = false;
+    }
+
     #[inline]
     fn input(&self) -> &Input {
         &self.cfg.input

--- a/crates/erg_compiler/compile.rs
+++ b/crates/erg_compiler/compile.rs
@@ -251,4 +251,8 @@ impl Compiler {
         let desugared = HIRDesugarer::desugar(hir);
         Ok(CompleteArtifact::new(desugared, artifact.warns))
     }
+
+    pub fn initialize_generator(&mut self) {
+        self.code_generator.initialize();
+    }
 }

--- a/src/scripts/repl_server.py
+++ b/src/scripts/repl_server.py
@@ -4,7 +4,7 @@ import socket as __socket
 import sys as __sys
 import importlib as __importlib
 import io as __io
-import traceback
+import traceback as __traceback
 
 __server_socket = __socket.socket()
 # DummyVM will replace this __PORT__ with free port
@@ -33,13 +33,18 @@ while True:
                 __res = str(exec('__importlib.reload(__MODULE__)', __ctx))
             else:
                 __res = str(exec('import __MODULE__', __ctx))
+            __already_loaded = True
         except SystemExit:
             __client_socket.send('[Exception] SystemExit'.encode())
             continue
         except Exception as e:
-            __exc = ''.join(traceback.format_exception(e)).rstrip()
-            traceback.clear_frames(e.__traceback__)
-        __already_loaded = True
+            try:
+                excs = __traceback.format_exception(e)
+            except:
+                excs = __traceback.format_exception_only(e.__class__, e)
+            __exc = ''.join(excs).rstrip()
+            __traceback.clear_frames(e.__traceback__)
+            __client_socket.send('[Initialize]'.encode())
         __out = __sys.stdout.getvalue()[:-1]
         __res = __out + __exc + '\n' + __res
         __client_socket.send(__res.encode())

--- a/src/scripts/repl_server.py
+++ b/src/scripts/repl_server.py
@@ -4,6 +4,7 @@ import socket as __socket
 import sys as __sys
 import importlib as __importlib
 import io as __io
+import traceback
 
 __server_socket = __socket.socket()
 # DummyVM will replace this __PORT__ with free port
@@ -12,7 +13,7 @@ __server_socket.listen(1)
 (__client_socket, __client_address) = __server_socket.accept()
 
 __already_loaded = False
-__res = ''
+__ctx = {'__importlib': __importlib}
 
 while True:
     try:
@@ -24,20 +25,23 @@ while True:
         break
     elif __order == 'load':
         __sys.stdout = __io.StringIO()
+        __res = ''
+        __exc = ''
         try:
             if __already_loaded:
                 # __MODULE__ will be replaced with module name
-                __res = str(exec('__importlib.reload(__MODULE__)'))
+                __res = str(exec('__importlib.reload(__MODULE__)', __ctx))
             else:
-                __res = str(exec('import __MODULE__'))
+                __res = str(exec('import __MODULE__', __ctx))
         except SystemExit:
             __client_socket.send('[Exception] SystemExit'.encode())
             continue
-        except e:
-            __res = str(e)
+        except Exception as e:
+            __exc = ''.join(traceback.format_exception(e)).rstrip()
+            traceback.clear_frames(e.__traceback__)
         __already_loaded = True
         __out = __sys.stdout.getvalue()[:-1]
-        __res = __out + '\n' + __res
+        __res = __out + __exc + '\n' + __res
         __client_socket.send(__res.encode())
     else:
         __client_socket.send('unknown operation'.encode())

--- a/src/scripts/repl_server.py
+++ b/src/scripts/repl_server.py
@@ -46,7 +46,10 @@ while True:
             __traceback.clear_frames(e.__traceback__)
             __client_socket.send('[Initialize]'.encode())
         __out = __sys.stdout.getvalue()[:-1]
-        __res = __out + __exc + '\n' + __res
+        # assert not(__exc and __res)
+        if __exc or __res:
+            __out += '\n'
+        __res = __out + __exc + __res
         __client_socket.send(__res.encode())
     else:
         __client_socket.send('unknown operation'.encode())


### PR DESCRIPTION
Fixes https://github.com/erg-lang/erg/issues/419.

This is a brief description.
1. fix the repl server crashed after exception
2. exec user code in independent context.
3. return exception info to client through the socket.

@mtshiba
