### PR TITLE
fix(pystd): sync some decls in typing module

### DIFF
--- a/crates/erg_compiler/lib/pystd/collections.d/abc.d.er
+++ b/crates/erg_compiler/lib/pystd/collections.d/abc.d.er
@@ -18,7 +18,7 @@
 .Sequence: ClassType
 .Sequence.
     __getitem__: Type -> Type
-.MutableSqunce: ClassType
+.MutableSequence: ClassType
 .ByteString: ClassType
 .Set: ClassType
 .MutableSet: ClassType

--- a/crates/erg_compiler/lib/pystd/typing.d.er
+++ b/crates/erg_compiler/lib/pystd/typing.d.er
@@ -65,3 +65,39 @@
 .assert_type: (val: Obj, typ: Type) -> NoneType
 .assert_never: (arg: Obj) -> NoneType
 .reveal_type: (obj: Obj) -> NoneType
+
+.AbstractSet: (Type) -> Type
+.ByteString: ClassType
+.Container: ClassType
+.ContextManager: ClassType
+.ContextManager.
+    __enter__: (self: ContextManager) -> ContextManager
+    __exit__: (self: ContextManager, exc_type: Type, exc_value: Obj, traceback: Obj) -> NoneType
+.Hashable: ClassType
+.ItemsView: ClassType
+.Iterable: ClassType
+.Iterable.
+    __getitem__: Type -> Type
+.Iterator: ClassType
+.Iterator.
+    __getitem__: Type -> Type
+.KeysView: ClassType
+.Mapping: ClassType
+.Mapping.
+    __getitem__: (Type, Type) -> Type
+.MappingView: ClassType
+.MutableMapping: ClassType
+.MutableSequence: ClassType
+.MutableSet: ClassType
+.Sized: ClassType
+.ValuesView: ClassType
+.Awaitable: ClassType
+.AsyncIterator: ClassType
+.AsyncIterable: ClassType
+.Coroutine: ClassType
+.Collection: ClassType
+.AsyncGenerator: ClassType
+.AsyncContextManager: ClassType
+
+.Genertor: ClassType
+.Reversible: ClassType

--- a/crates/erg_compiler/lib/pystd/typing.d.er
+++ b/crates/erg_compiler/lib/pystd/typing.d.er
@@ -66,7 +66,9 @@
 .assert_never: (arg: Obj) -> NoneType
 .reveal_type: (obj: Obj) -> NoneType
 
-.AbstractSet: (Type) -> Type
+.AbstractSet: ClassType
+.AbstractSet.
+    __getitem__: (Type) -> Type
 .ByteString: ClassType
 .Container: ClassType
 .ContextManager: ClassType


### PR DESCRIPTION
Fixes: https://github.com/erg-lang/erg/issues/424


This is a brief description:
-
https://github.com/python/cpython/blob/376137f6ec73e0800e49cec6100e401f6154b693/Lib/typing.py#L63-L87

```
    # ABCs (from collections.abc).
    'AbstractSet',  # collections.abc.Set.
    'ByteString',
    'Container',
    'ContextManager',
    'Hashable',
    'ItemsView',
    'Iterable',
    'Iterator',
    'KeysView',
    'Mapping',
    'MappingView',
    'MutableMapping',
    'MutableSequence',
    'MutableSet',
    'Sequence',
    'Sized',
    'ValuesView',
    'Awaitable',
    'AsyncIterator',
    'AsyncIterable',
    'Coroutine',
    'Collection',
    'AsyncGenerator',
    'AsyncContextManager',
```

There are 24 items, including the `Sequence` which has already been added. So,  I add 23 items.

Changes proposed in this PR:
-
-

@mtshiba
