### PR TITLE
Fix REPL

### DIFF
--- a/crates/erg_common/stdin.rs
+++ b/crates/erg_common/stdin.rs
@@ -6,7 +6,7 @@ use std::io::{stdin, BufRead, BufReader};
 
 #[cfg(feature = "full-repl")]
 use crossterm::{
-    cursor::{CursorShape, MoveToColumn, SetCursorShape},
+    cursor::{MoveToColumn},
     event::{read, Event, KeyCode, KeyEvent, KeyModifiers},
     execute,
     style::Print,
@@ -103,7 +103,6 @@ impl StdinReader {
     pub fn read(&mut self) -> String {
         enable_raw_mode().unwrap();
         let mut output = std::io::stdout();
-        execute!(output, SetCursorShape(CursorShape::Line)).unwrap();
         let mut line = String::new();
         self.input(&mut line).unwrap();
         disable_raw_mode().unwrap();
@@ -124,7 +123,7 @@ impl StdinReader {
         {
             consult_history = false;
             match (code, modifiers) {
-                (KeyCode::Char('z'), KeyModifiers::CONTROL) => {
+                (KeyCode::Char('z'), KeyModifiers::CONTROL) | (KeyCode::Char('d'), KeyModifiers::CONTROL) => {
                     println!();
                     line.clear();
                     line.push_str(":exit");


### PR DESCRIPTION
Fixes #429 
Fixes #428 

1. Delete the code of cursor change
2. Support Ctrl + D/Z to exit at the same time

@mtshiba
