### PR TITLE
fix jsonrpc version type to honor JSON-RPC protocol spec

### DIFF
--- a/crates/els/message.rs
+++ b/crates/els/message.rs
@@ -80,7 +80,7 @@ impl ShowMessage {
 
 #[derive(Serialize)]
 pub struct LSPResult<R: Serialize> {
-    jsonrpc: f32,
+    jsonrpc: String,
     id: i64,
     result: R,
 }
@@ -88,7 +88,7 @@ pub struct LSPResult<R: Serialize> {
 impl<R: Serialize> LSPResult<R> {
     pub fn new(id: i64, result: R) -> Self {
         Self {
-            jsonrpc: 2.0,
+            jsonrpc: "2.0".into(),
             id,
             result,
         }


### PR DESCRIPTION
Hi!

I'm trying `pylyzer` with [Helix](https://helix-editor.com/) editor.
This fix allow  to use pylyzer.

In specification https://www.jsonrpc.org/specification#response_object
```
jsonrpc
  A String specifying the version of the JSON-RPC protocol. MUST be exactly "2.0".
```

to enable pylyzer in helix:  ~/.config/helix/languages.toml
```toml
[language-server]
pylyzer = { command = "pylyzer", args = ["--server"] }

[[language]]
name = "python"
language-servers = [ "pylyzer" ]
auto-format = true
# TODO: pyls needs utf-8 offsets
indent = { tab-width = 4, unit = "    " }
```


