### PR TITLE
ci: set test timeout to 20 minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       RUST_BACKTRACE: full
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
I set the timeout for the test to 20 minutes because in the past the time it took for a successful CI test was about 10 minutes or less. (The default timeout of 6 hours is too long)

@mtshiba
