### PR TITLE
Type narrowing with `filter`

### DIFF
--- a/crates/erg_compiler/context/compare.rs
+++ b/crates/erg_compiler/context/compare.rs
@@ -377,7 +377,11 @@ impl Context {
                 let same_params_len = ls.non_default_params.len() == rs.non_default_params.len()
                     || rs.var_params.is_some();
                 // && ls.default_params.len() <= rs.default_params.len();
-                let return_t_judge = self.supertype_of(&ls.return_t, &rs.return_t); // covariant
+                let rhs_ret = rs
+                    .return_t
+                    .clone()
+                    .replace_params(rs.param_names(), ls.param_names());
+                let return_t_judge = self.supertype_of(&ls.return_t, &rhs_ret); // covariant
                 let non_defaults_judge = ls
                     .non_default_params
                     .iter()
@@ -538,6 +542,10 @@ impl Context {
                 true
             }
             (Bool, Guard { .. }) => true,
+            (Guard(lhs), Guard(rhs)) => {
+                !rhs.to.is_refinement() // TODO: refinement guard is unstable
+                && lhs.target == rhs.target && self.supertype_of(&lhs.to, &rhs.to)
+            }
             (Mono(n), NamedTuple(_)) => &n[..] == "GenericNamedTuple" || &n[..] == "GenericTuple",
             (Mono(n), Record(_)) => &n[..] == "Record",
             (ty @ (Type | ClassType | TraitType), Record(rec)) => {
@@ -1500,6 +1508,30 @@ impl Context {
         }
     }
 
+    pub(crate) fn union_pred(&self, lhs: Predicate, rhs: Predicate) -> Predicate {
+        match (
+            self.is_super_pred_of(&lhs, &rhs),
+            self.is_sub_pred_of(&lhs, &rhs),
+        ) {
+            (true, true) => lhs,  // lhs = rhs
+            (true, false) => lhs, // lhs :> rhs
+            (false, true) => rhs,
+            (false, false) => lhs | rhs,
+        }
+    }
+
+    pub(crate) fn intersection_pred(&self, lhs: Predicate, rhs: Predicate) -> Predicate {
+        match (
+            self.is_super_pred_of(&lhs, &rhs),
+            self.is_sub_pred_of(&lhs, &rhs),
+        ) {
+            (true, true) => lhs,
+            (true, false) => rhs,
+            (false, true) => lhs,
+            (false, false) => lhs & rhs,
+        }
+    }
+
     pub(crate) fn union_refinement(
         &self,
         lhs: &RefinementType,
@@ -1509,8 +1541,8 @@ impl Context {
         let union = self.union(&lhs.t, &rhs.t);
         let name = lhs.var.clone();
         let rhs_pred = rhs.pred.clone().change_subject_name(name);
-        // FIXME: predの包含関係も考慮する
-        RefinementType::new(lhs.var.clone(), union, *lhs.pred.clone() | rhs_pred)
+        let union_pred = self.union_pred(*lhs.pred.clone(), rhs_pred);
+        RefinementType::new(lhs.var.clone(), union, union_pred)
     }
 
     /// Returns intersection of two types (`A and B`).
@@ -1614,6 +1646,7 @@ impl Context {
     /// ```erg
     /// {I: Int | I > 0} and {I: Int | I < 10} == {I: Int | I > 0 and I < 10}
     /// {x: Int or NoneType | True} and {x: Obj | x != None} == {x: Int or NoneType | x != None} (== Int)
+    /// {x: Nat or None | x == 1 or x == None} and {x: Int | True} == {x: Int | x == 1}
     /// ```
     fn intersection_refinement(
         &self,
@@ -1623,7 +1656,13 @@ impl Context {
         let intersec = self.intersection(&lhs.t, &rhs.t);
         let name = lhs.var.clone();
         let rhs_pred = rhs.pred.clone().change_subject_name(name);
-        RefinementType::new(lhs.var.clone(), intersec, *lhs.pred.clone() & rhs_pred)
+        let intersection_pred = self.intersection_pred(*lhs.pred.clone(), rhs_pred);
+        let Some(pred) =
+            self.eliminate_type_mismatched_preds(&lhs.var, &intersec, intersection_pred)
+        else {
+            return RefinementType::new(lhs.var.clone(), intersec, Predicate::TRUE);
+        };
+        RefinementType::new(lhs.var.clone(), intersec, pred)
     }
 
     /// ```erg
@@ -1782,6 +1821,50 @@ impl Context {
             }
         }
         reduced
+    }
+
+    fn eliminate_type_mismatched_preds(
+        &self,
+        var: &str,
+        t: &Type,
+        pred: Predicate,
+    ) -> Option<Predicate> {
+        match pred {
+            Predicate::Equal { ref lhs, ref rhs }
+            | Predicate::NotEqual { ref lhs, ref rhs }
+            | Predicate::GreaterEqual { ref lhs, ref rhs }
+            | Predicate::LessEqual { ref lhs, ref rhs }
+                if lhs == var =>
+            {
+                let rhs_t = self.get_tp_t(rhs).unwrap_or(Obj);
+                if !self.subtype_of(&rhs_t, t) {
+                    None
+                } else {
+                    Some(pred)
+                }
+            }
+            Predicate::And(l, r) => {
+                let l = self.eliminate_type_mismatched_preds(var, t, *l);
+                let r = self.eliminate_type_mismatched_preds(var, t, *r);
+                match (l, r) {
+                    (Some(l), Some(r)) => Some(l & r),
+                    (Some(l), None) => Some(l),
+                    (None, Some(r)) => Some(r),
+                    (None, None) => None,
+                }
+            }
+            Predicate::Or(l, r) => {
+                let l = self.eliminate_type_mismatched_preds(var, t, *l);
+                let r = self.eliminate_type_mismatched_preds(var, t, *r);
+                match (l, r) {
+                    (Some(l), Some(r)) => Some(l | r),
+                    (Some(l), None) => Some(l),
+                    (None, Some(r)) => Some(r),
+                    (None, None) => None,
+                }
+            }
+            _ => Some(pred),
+        }
     }
 
     /// see doc/LANG/compiler/refinement_subtyping.md

--- a/crates/erg_compiler/context/generalize.rs
+++ b/crates/erg_compiler/context/generalize.rs
@@ -298,6 +298,10 @@ impl Generalizer {
                     res
                 }
             }
+            Guard(grd) => {
+                let to = self.generalize_t(*grd.to, uninit);
+                guard(grd.namespace, grd.target, to)
+            }
             // REVIEW: その他何でもそのまま通していいのか?
             other => other,
         }
@@ -730,11 +734,11 @@ impl<'c, 'q, 'l, L: Locational> Dereferencer<'c, 'q, 'l, L> {
     // ```
     pub(crate) fn deref_tyvar(&mut self, t: Type) -> TyCheckResult<Type> {
         match t {
-            Type::FreeVar(fv) if fv.is_linked() => {
+            FreeVar(fv) if fv.is_linked() => {
                 let t = fv.unwrap_linked();
                 self.deref_tyvar(t)
             }
-            Type::FreeVar(mut fv)
+            FreeVar(mut fv)
                 if fv.is_generalized() && self.qnames.contains(&fv.unbound_name().unwrap()) =>
             {
                 fv.update_init();
@@ -745,7 +749,7 @@ impl<'c, 'q, 'l, L: Locational> Dereferencer<'c, 'q, 'l, L> {
             // ?T(<: Int, :> Add(?T)) ==> Int
             // ?T(:> Nat, <: Sub(Str)) ==> Error!
             // ?T(:> {1, "a"}, <: Eq(?T(:> {1, "a"}, ...)) ==> Error!
-            Type::FreeVar(fv) if fv.constraint_is_sandwiched() => {
+            FreeVar(fv) if fv.constraint_is_sandwiched() => {
                 let (sub_t, super_t) = fv.get_subsup().unwrap();
                 if self.level <= fv.level().unwrap() {
                     // we need to force linking to avoid infinite loop
@@ -792,7 +796,7 @@ impl<'c, 'q, 'l, L: Locational> Dereferencer<'c, 'q, 'l, L> {
                     Ok(Type::FreeVar(fv))
                 }
             }
-            Type::FreeVar(fv) if fv.is_unbound() => {
+            FreeVar(fv) if fv.is_unbound() => {
                 if self.level == 0 {
                     match &*fv.crack_constraint() {
                         Constraint::TypeOf(t) if !t.is_type() => {
@@ -812,7 +816,7 @@ impl<'c, 'q, 'l, L: Locational> Dereferencer<'c, 'q, 'l, L> {
                     Ok(Type::FreeVar(fv))
                 }
             }
-            Type::Poly { name, mut params } => {
+            Poly { name, mut params } => {
                 let typ = poly(&name, params.clone());
                 let ctx = self.ctx.get_nominal_type_ctx(&typ).ok_or_else(|| {
                     TyCheckError::type_not_found(
@@ -834,7 +838,7 @@ impl<'c, 'q, 'l, L: Locational> Dereferencer<'c, 'q, 'l, L> {
                 }
                 Ok(Type::Poly { name, params })
             }
-            Type::Subr(mut subr) => {
+            Subr(mut subr) => {
                 for param in subr.non_default_params.iter_mut() {
                     self.push_variance(Contravariant);
                     *param.typ_mut() =
@@ -874,7 +878,7 @@ impl<'c, 'q, 'l, L: Locational> Dereferencer<'c, 'q, 'l, L> {
                 self.pop_variance();
                 Ok(Type::Subr(subr))
             }
-            Type::Callable {
+            Callable {
                 mut param_ts,
                 return_t,
             } => {
@@ -884,12 +888,12 @@ impl<'c, 'q, 'l, L: Locational> Dereferencer<'c, 'q, 'l, L> {
                 let return_t = self.deref_tyvar(*return_t)?;
                 Ok(callable(param_ts, return_t))
             }
-            Type::Quantified(subr) => self.eliminate_needless_quant(*subr),
-            Type::Ref(t) => {
+            Quantified(subr) => self.eliminate_needless_quant(*subr),
+            Ref(t) => {
                 let t = self.deref_tyvar(*t)?;
                 Ok(ref_(t))
             }
-            Type::RefMut { before, after } => {
+            RefMut { before, after } => {
                 let before = self.deref_tyvar(*before)?;
                 let after = if let Some(after) = after {
                     Some(self.deref_tyvar(*after)?)
@@ -898,38 +902,38 @@ impl<'c, 'q, 'l, L: Locational> Dereferencer<'c, 'q, 'l, L> {
                 };
                 Ok(ref_mut(before, after))
             }
-            Type::Record(mut rec) => {
+            Record(mut rec) => {
                 for (_, field) in rec.iter_mut() {
                     *field = self.deref_tyvar(mem::take(field))?;
                 }
                 Ok(Type::Record(rec))
             }
-            Type::NamedTuple(mut rec) => {
+            NamedTuple(mut rec) => {
                 for (_, t) in rec.iter_mut() {
                     *t = self.deref_tyvar(mem::take(t))?;
                 }
                 Ok(Type::NamedTuple(rec))
             }
-            Type::Refinement(refine) => {
+            Refinement(refine) => {
                 let t = self.deref_tyvar(*refine.t)?;
                 let pred = self.deref_pred(*refine.pred)?;
                 Ok(refinement(refine.var, t, pred))
             }
-            Type::And(l, r) => {
+            And(l, r) => {
                 let l = self.deref_tyvar(*l)?;
                 let r = self.deref_tyvar(*r)?;
                 Ok(self.ctx.intersection(&l, &r))
             }
-            Type::Or(l, r) => {
+            Or(l, r) => {
                 let l = self.deref_tyvar(*l)?;
                 let r = self.deref_tyvar(*r)?;
                 Ok(self.ctx.union(&l, &r))
             }
-            Type::Not(ty) => {
+            Not(ty) => {
                 let ty = self.deref_tyvar(*ty)?;
                 Ok(self.ctx.complement(&ty))
             }
-            Type::Proj { lhs, rhs } => {
+            Proj { lhs, rhs } => {
                 let proj = self
                     .ctx
                     .eval_proj(*lhs.clone(), rhs.clone(), self.level, self.loc)
@@ -940,7 +944,7 @@ impl<'c, 'q, 'l, L: Locational> Dereferencer<'c, 'q, 'l, L> {
                     .unwrap_or(Failure);
                 Ok(proj)
             }
-            Type::ProjCall {
+            ProjCall {
                 lhs,
                 attr_name,
                 args,
@@ -956,9 +960,13 @@ impl<'c, 'q, 'l, L: Locational> Dereferencer<'c, 'q, 'l, L> {
                     .unwrap_or(Failure);
                 Ok(proj)
             }
-            Type::Structural(inner) => {
+            Structural(inner) => {
                 let inner = self.deref_tyvar(*inner)?;
                 Ok(inner.structuralize())
+            }
+            Guard(grd) => {
+                let to = self.deref_tyvar(*grd.to)?;
+                Ok(guard(grd.namespace, grd.target, to))
             }
             t => Ok(t),
         }
@@ -975,11 +983,11 @@ impl<'c, 'q, 'l, L: Locational> Dereferencer<'c, 'q, 'l, L> {
             }*/
             // See tests\should_err\subtyping.er:8~13
             (
-                Type::Poly {
+                Poly {
                     name: ln,
                     params: lps,
                 },
-                Type::Poly {
+                Poly {
                     name: rn,
                     params: rps,
                 },
@@ -1565,7 +1573,7 @@ impl Context {
     /// ```
     pub(crate) fn squash_tyvar(&self, typ: Type) -> Type {
         match typ {
-            Type::Or(l, r) => {
+            Or(l, r) => {
                 let l = self.squash_tyvar(*l);
                 let r = self.squash_tyvar(*r);
                 // REVIEW:
@@ -1582,7 +1590,7 @@ impl Context {
                 }
                 self.union(&l, &r)
             }
-            Type::FreeVar(ref fv) if fv.constraint_is_sandwiched() => {
+            FreeVar(ref fv) if fv.constraint_is_sandwiched() => {
                 let (sub_t, super_t) = fv.get_subsup().unwrap();
                 let sub_t = self.squash_tyvar(sub_t);
                 let super_t = self.squash_tyvar(super_t);

--- a/crates/erg_compiler/context/inquire.rs
+++ b/crates/erg_compiler/context/inquire.rs
@@ -2166,7 +2166,7 @@ impl Context {
         } else {
             passed_params.insert(Str::from(format!("({} param)", ordinal_num(nth))));
         }
-        self.sub_unify(arg_t, param_t, arg, param.name())
+        self.sub_unify_with_coercion(arg_t, param_t, arg, param.name())
             .map_err(|errs| {
                 log!(err "semi-unification failed with {callee}\n{arg_t} !<: {param_t}");
                 let name = if let Some(attr) = attr_name {
@@ -2217,7 +2217,7 @@ impl Context {
     ) -> TyCheckResult<()> {
         let arg_t = arg.ref_t();
         let param_t = param.typ();
-        self.sub_unify(arg_t, param_t, arg, param.name())
+        self.sub_unify_with_coercion(arg_t, param_t, arg, param.name())
             .map_err(|errs| {
                 log!(err "semi-unification failed with {callee}\n{arg_t} !<: {param_t}");
                 let name = if let Some(attr) = attr_name {
@@ -2277,7 +2277,7 @@ impl Context {
         {
             let param_t = pt.typ();
             passed_params.insert(kw_name.clone());
-            self.sub_unify(arg_t, param_t, arg, Some(kw_name))
+            self.sub_unify_with_coercion(arg_t, param_t, arg, Some(kw_name))
                 .map_err(|errs| {
                     log!(err "semi-unification failed with {callee}\n{arg_t} !<: {}", pt.typ());
                     let name = if let Some(attr) = attr_name {
@@ -2309,7 +2309,7 @@ impl Context {
                     )
                 })?;
         } else if let Some(kw_var) = subr_ty.kw_var_params.as_deref() {
-            self.sub_unify(arg_t, kw_var.typ(), arg, Some(kw_name))?;
+            self.sub_unify_with_coercion(arg_t, kw_var.typ(), arg, Some(kw_name))?;
         } else {
             let similar =
                 levenshtein::get_similar_name(subr_ty.param_names(), arg.keyword.inspect());

--- a/crates/erg_compiler/context/instantiate.rs
+++ b/crates/erg_compiler/context/instantiate.rs
@@ -16,6 +16,7 @@ use crate::ty::constructors::*;
 use crate::ty::free::{Constraint, FreeTyParam, FreeTyVar, HasLevel, GENERIC_LEVEL};
 use crate::ty::typaram::{TyParam, TyParamLambda};
 use crate::ty::ConstSubr;
+use crate::ty::GuardType;
 use crate::ty::ValueObj;
 use crate::ty::{HasType, Predicate, Type};
 use crate::{type_feature_error, unreachable_error};
@@ -918,6 +919,14 @@ impl Context {
             Not(ty) => {
                 let ty = self.instantiate_t_inner(*ty, tmp_tv_cache, loc)?;
                 Ok(self.complement(&ty))
+            }
+            Guard(guard) => {
+                let to = self.instantiate_t_inner(*guard.to, tmp_tv_cache, loc)?;
+                Ok(Type::Guard(GuardType::new(
+                    guard.namespace,
+                    guard.target,
+                    to,
+                )))
             }
             other if other.is_monomorphic() => Ok(other),
             other => type_feature_error!(self, loc.loc(), &format!("instantiating type {other}")),

--- a/crates/erg_compiler/context/unify.rs
+++ b/crates/erg_compiler/context/unify.rs
@@ -1377,6 +1377,9 @@ impl<'c, 'l, 'u, L: Locational> Unifier<'c, 'l, 'u, L> {
             (Structural(sub), Structural(sup)) => {
                 self.sub_unify(sub, sup)?;
             }
+            (Guard(sub), Guard(sup)) => {
+                self.sub_unify(&sub.to, &sup.to)?;
+            }
             (sub, Structural(sup)) => {
                 let sub_fields = self.ctx.fields(sub);
                 for (sup_field, sup_ty) in self.ctx.fields(sup) {

--- a/crates/erg_compiler/lint.rs
+++ b/crates/erg_compiler/lint.rs
@@ -32,8 +32,8 @@ impl<ASTBuilder: ASTBuildable> GenericASTLowerer<ASTBuilder> {
     ) -> SingleLowerResult<()> {
         self.module
             .context
-            .sub_unify(found, expect, loc, Some(name))
-            .map_err(|_| {
+            .sub_unify_with_coercion(found, expect, loc, Some(name))
+            .map_err(|_err| {
                 LowerError::type_mismatch_error(
                     self.cfg().input.clone(),
                     line!() as usize,

--- a/crates/erg_compiler/tests/infer.er
+++ b/crates/erg_compiler/tests/infer.er
@@ -38,3 +38,6 @@ val!() =
         val!::return x
     "d"
 val = val!()
+
+xs as [Nat or Str; _] = [1, 2, "aa"]
+ys = array filter x -> x in Int, xs

--- a/crates/erg_compiler/tests/test.rs
+++ b/crates/erg_compiler/tests/test.rs
@@ -90,6 +90,9 @@ fn _test_infer_types() -> Result<(), ()> {
     module
         .context
         .assert_var_type("val", &v_enum(set! { "b".into(), "d".into() }))?;
+    module
+        .context
+        .assert_var_type("ys", &unknown_len_array_t(Nat))?;
     Ok(())
 }
 

--- a/crates/erg_compiler/ty/mod.rs
+++ b/crates/erg_compiler/ty/mod.rs
@@ -19,6 +19,7 @@ pub mod vis;
 
 use std::cell::RefMut;
 use std::fmt;
+use std::hash::{Hash, Hasher};
 use std::ops::{BitAnd, BitOr, Deref, Not, Range, RangeInclusive};
 use std::path::PathBuf;
 
@@ -972,7 +973,7 @@ impl ArgsOwnership {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone)]
 pub enum CastTarget {
     Arg {
         nth: usize,
@@ -985,6 +986,29 @@ pub enum CastTarget {
     },
     // NOTE: `Expr(Expr)` causes a bad memory access error
     Expr(Box<Expr>),
+}
+
+impl PartialEq for CastTarget {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Arg { nth: l, .. }, Self::Arg { nth: r, .. }) => l == r,
+            (Self::Var { name: l, .. }, Self::Var { name: r, .. }) => l == r,
+            (Self::Expr(l), Self::Expr(r)) => l == r,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for CastTarget {}
+
+impl Hash for CastTarget {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Arg { nth, .. } => nth.hash(state),
+            Self::Var { name, .. } => name.hash(state),
+            Self::Expr(expr) => expr.hash(state),
+        }
+    }
 }
 
 impl fmt::Display for CastTarget {
@@ -1053,9 +1077,9 @@ impl GuardType {
         }
     }
 
-    pub fn replace_param(mut self, target: &Str, to: &Str) -> Self {
+    pub fn replace_param(mut self, target: &str, to: &str) -> Self {
         match &mut self.target {
-            CastTarget::Arg { name, .. } if name == target => *name = to.clone(),
+            CastTarget::Arg { name, .. } if name == target => *name = Str::rc(to),
             _ => {}
         }
         self
@@ -2304,6 +2328,15 @@ impl Type {
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().is_array(),
             Self::Poly { name, .. } => &name[..] == "Array",
             Self::Refinement(refine) => refine.t.is_array(),
+            _ => false,
+        }
+    }
+
+    pub fn is_guard(&self) -> bool {
+        match self {
+            Self::FreeVar(fv) if fv.is_linked() => fv.crack().is_guard(),
+            Self::Guard(_) => true,
+            Self::Refinement(refine) => refine.t.is_guard(),
             _ => false,
         }
     }
@@ -3735,7 +3768,7 @@ impl Type {
         }
     }
 
-    fn replace_param(self, target: &Str, to: &Str) -> Self {
+    fn replace_param(self, target: &str, to: &str) -> Self {
         match self {
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().clone().replace_param(target, to),
             Self::Refinement(mut refine) => {
@@ -3746,6 +3779,17 @@ impl Type {
             Self::Guard(guard) => Self::Guard(guard.replace_param(target, to)),
             _ => self,
         }
+    }
+
+    pub fn replace_params<'l, 'r>(
+        mut self,
+        target: impl Iterator<Item = &'l str>,
+        to: impl Iterator<Item = &'r str>,
+    ) -> Self {
+        for (target, to) in target.zip(to) {
+            self = self.replace_param(target, to);
+        }
+        self
     }
 
     /// TyParam::Value(ValueObj::Type(_)) => TyParam::Type

--- a/crates/erg_compiler/ty/typaram.rs
+++ b/crates/erg_compiler/ty/typaram.rs
@@ -1148,6 +1148,29 @@ impl TyParam {
         }
     }
 
+    pub fn coerce(&self, list: Option<&UndoableLinkedList>) {
+        if let Some(list) = list {
+            self.undoable_coerce(list);
+        } else {
+            self.destructive_coerce();
+        }
+    }
+
+    pub fn undoable_coerce(&self, list: &UndoableLinkedList) {
+        match self {
+            TyParam::FreeVar(fv) if fv.is_linked() => {
+                fv.crack().undoable_coerce(list);
+            }
+            TyParam::FreeVar(fv) if fv.is_unbound() => {
+                let typ = fv.get_type().unwrap();
+                typ.undoable_coerce(list);
+            }
+            TyParam::Type(t) => t.undoable_coerce(list),
+            // TODO:
+            _ => {}
+        }
+    }
+
     pub fn destructive_coerce(&self) {
         match self {
             TyParam::FreeVar(fv) if fv.is_linked() => {

--- a/crates/erg_compiler/ty/value.rs
+++ b/crates/erg_compiler/ty/value.rs
@@ -974,6 +974,10 @@ impl ValueObj {
         ))
     }
 
+    pub const fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+
     // TODO: add Complex
     pub const fn is_num(&self) -> bool {
         matches!(

--- a/tests/should_ok/assert_cast.er
+++ b/tests/should_ok/assert_cast.er
@@ -40,3 +40,8 @@ assert s3 in (Int or NoneType or Str)
 p! as Obj = print!
 assert p! in (*objs: Obj) => NoneType
 p!("OK")
+
+xs: [Nat or NoneType; _] = [1, None, 2]
+ys: [Nat; _] = array filter x -> x != None, xs
+nats _: [Nat; _] = None
+nats ys


### PR DESCRIPTION
Now, this code passes type checking.

```python
xs: [Nat or NoneType; _] = [1, None, 2]
ys: [Nat; _] = array filter x -> x != None, xs
```
