### PR TITLE
Erg pystd fixes

### DIFF
--- a/crates/erg_compiler/lib/pystd/abc.d.er
+++ b/crates/erg_compiler/lib/pystd/abc.d.er
@@ -7,6 +7,7 @@
 .ABCMeta.
     __instancecheck__: (self: .ABCMeta, instance: Obj) -> Bool
     __subclasscheck__: (self: .ABCMeta, subclass: Type) -> Bool
+    __subclasshook__: (self: .ABCMeta, subclass: Type) -> Bool
     register: (self: .ABCMeta, subclass: Type) -> NoneType
 
 .ABC: ClassType

--- a/crates/erg_compiler/lib/pystd/abc.d.er
+++ b/crates/erg_compiler/lib/pystd/abc.d.er
@@ -1,6 +1,6 @@
-.abstructmethod: |F <: GenericCallable|(F) -> F
-.abstructclassmethod: |F <: GenericCallable|(F) -> F
-.abstructstaticmethod: |F <: GenericCallable|(F) -> F
+.abstractmethod: |F <: GenericCallable|(F) -> F
+.abstractclassmethod: |F <: GenericCallable|(F) -> F
+.abstractstaticmethod: |F <: GenericCallable|(F) -> F
 
 .ABCMeta: ClassType
 .ABCMeta <: Type


### PR DESCRIPTION
Relates to #213 

The following PR fixes a typo in abc.d.er and add missing __subclasshook__ api.

Changes proposed in this PR:
- feat(erg): add subclasshook method in abc.d.er
- fix(erg_compiler): fix typo in abc.d.er otherwise linting an interface that use subclasshook method will fail

@mtshiba
