### PR TITLE
Update links from unofficial nixos wiki to official one

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ cd erg
 nix-build
 ```
 
-If you've been enabled [Nix Flakes](https://nixos.wiki/wiki/Flakes).
+If you've been enabled [Nix Flakes](https://wiki.nixos.org/wiki/Flakes).
 
 ```sh
 git clone https://github.com/erg-lang/erg.git

--- a/README_JA.md
+++ b/README_JA.md
@@ -190,7 +190,7 @@ cd erg
 nix-build
 ```
 
-[Nix Flakes](https://nixos.wiki/wiki/Flakes)を有効化している場合は次のコマンドでも良いです.
+[Nix Flakes](https://wiki.nixos.org/wiki/Flakes)を有効化している場合は次のコマンドでも良いです.
 
 ```sh
 git clone https://github.com/erg-lang/erg.git

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -188,7 +188,7 @@ cd erg
 nix-build
 ```
 
-如果您已启用 [Nix Flakes](https://nixos.wiki/wiki/Flakes)
+如果您已启用 [Nix Flakes](https://wiki.nixos.org/wiki/Flakes)
 
 ```sh
 git clone https://github.com/erg-lang/erg.git

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -188,7 +188,7 @@ cd erg
 nix-build
 ```
 
-如果您已啟用 [Nix Flakes](https://nixos.wiki/wiki/Flakes)
+如果您已啟用 [Nix Flakes](https://wiki.nixos.org/wiki/Flakes)
 
 ```sh
 git clone https://github.com/erg-lang/erg.git


### PR DESCRIPTION
Updates the link in the README's for each language to point to the new, official NixOS wiki that is being actively maintained.

Changes proposed in this PR:
- Change wiki links to point to new, official wiki

@mtshiba
