### PR TITLE
Change And/Or-type structures

### DIFF
--- a/crates/erg_common/dict.rs
+++ b/crates/erg_common/dict.rs
@@ -129,6 +129,18 @@ impl<K, V> Dict<K, V> {
         }
     }
 
+    /// ```
+    /// # use erg_common::dict;
+    /// # use erg_common::dict::Dict;
+    /// let mut dict = Dict::with_capacity(3);
+    /// assert_eq!(dict.capacity(), 3);
+    /// dict.insert("a", 1);
+    /// assert_eq!(dict.capacity(), 3);
+    /// dict.insert("b", 2);
+    /// dict.insert("c", 3);
+    /// dict.insert("d", 4);
+    /// assert_ne!(dict.capacity(), 3);
+    /// ```
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             dict: FxHashMap::with_capacity_and_hasher(capacity, Default::default()),

--- a/crates/erg_common/macros.rs
+++ b/crates/erg_common/macros.rs
@@ -627,6 +627,17 @@ impl RecursionCounter {
 
 #[macro_export]
 macro_rules! set_recursion_limit {
+    (panic, $msg:expr, $limit:expr) => {
+        use std::sync::atomic::AtomicU32;
+
+        static COUNTER: AtomicU32 = AtomicU32::new($limit);
+
+        let counter = $crate::macros::RecursionCounter::new(&COUNTER);
+        if counter.limit_reached() {
+            $crate::log!(err "Recursion limit reached");
+            panic!($msg);
+        }
+    };
     ($returns:expr, $limit:expr) => {
         use std::sync::atomic::AtomicU32;
 

--- a/crates/erg_common/set.rs
+++ b/crates/erg_common/set.rs
@@ -382,6 +382,20 @@ impl<T: Hash + Eq + Clone> Set<T> {
         self.insert(other);
         self
     }
+
+    /// ```
+    /// # use erg_common::set;
+    /// assert_eq!(set!{1, 2}.product(&set!{3, 4}), set!{(&1, &3), (&1, &4), (&2, &3), (&2, &4)});
+    /// ```
+    pub fn product<'l, 'r, U: Hash + Eq>(&'l self, other: &'r Set<U>) -> Set<(&'l T, &'r U)> {
+        let mut res = set! {};
+        for x in self.iter() {
+            for y in other.iter() {
+                res.insert((x, y));
+            }
+        }
+        res
+    }
 }
 
 impl<T: Hash + Ord> Set<T> {

--- a/crates/erg_common/traits.rs
+++ b/crates/erg_common/traits.rs
@@ -1407,6 +1407,8 @@ impl<T: Immutable + ?Sized> Immutable for &T {}
 impl<T: Immutable> Immutable for Option<T> {}
 impl<T: Immutable> Immutable for Vec<T> {}
 impl<T: Immutable> Immutable for [T] {}
+impl<T: Immutable, U: Immutable> Immutable for (T, U) {}
+impl<T: Immutable, U: Immutable, V: Immutable> Immutable for (T, U, V) {}
 impl<T: Immutable + ?Sized> Immutable for Box<T> {}
 impl<T: Immutable + ?Sized> Immutable for std::rc::Rc<T> {}
 impl<T: Immutable + ?Sized> Immutable for std::sync::Arc<T> {}

--- a/crates/erg_common/triple.rs
+++ b/crates/erg_common/triple.rs
@@ -18,6 +18,16 @@ impl<T: fmt::Display, E: fmt::Display> fmt::Display for Triple<T, E> {
 }
 
 impl<T, E> Triple<T, E> {
+    pub const fn is_ok(&self) -> bool {
+        matches!(self, Triple::Ok(_))
+    }
+    pub const fn is_err(&self) -> bool {
+        matches!(self, Triple::Err(_))
+    }
+    pub const fn is_none(&self) -> bool {
+        matches!(self, Triple::None)
+    }
+
     pub fn none_then(self, err: E) -> Result<T, E> {
         match self {
             Triple::None => Err(err),

--- a/crates/erg_compiler/build_package.rs
+++ b/crates/erg_compiler/build_package.rs
@@ -418,7 +418,7 @@ impl<ASTBuilder: ASTBuildable, HIRBuilder: Buildable>
         let res = self.resolve(&mut ast, &cfg);
         debug_assert!(res.is_ok(), "{:?}", res.unwrap_err());
         log!(info "Dependency resolution process completed");
-        println!("graph:\n{}", self.shared.graph.display());
+        log!("graph:\n{}", self.shared.graph.display());
         if self.parse_errors.errors.is_empty() {
             self.shared.warns.extend(self.parse_errors.warns.flush());
         // continue analysis if ELS mode
@@ -838,12 +838,9 @@ impl<ASTBuilder: ASTBuildable, HIRBuilder: Buildable>
             write!(out, "Checking 0/{nmods}").unwrap();
             out.flush().unwrap();
         }
-        println!("here?: {path}");
-        let mut limit = 100000;
         while let Some(ancestor) = ancestors.pop() {
             if graph.ancestors(&ancestor).is_empty() {
                 graph.remove(&ancestor);
-                limit = 100000;
                 if let Some(entry) = self.asts.remove(&ancestor) {
                     if print_progress {
                         let name = ancestor.file_name().unwrap_or_default().to_string_lossy();
@@ -864,10 +861,6 @@ impl<ASTBuilder: ASTBuildable, HIRBuilder: Buildable>
                     self.build_inlined_module(&ancestor, graph);
                 }
             } else {
-                limit -= 1;
-                if limit == 0 {
-                    panic!("{ancestor} is in a circular dependency");
-                }
                 ancestors.insert(0, ancestor);
             }
         }
@@ -950,7 +943,6 @@ impl<ASTBuilder: ASTBuildable, HIRBuilder: Buildable>
                 }
             }
         };
-        println!("Start to analyze {path}");
         if SINGLE_THREAD {
             run();
             self.shared.promises.mark_as_joined(path);

--- a/crates/erg_compiler/build_package.rs
+++ b/crates/erg_compiler/build_package.rs
@@ -418,7 +418,7 @@ impl<ASTBuilder: ASTBuildable, HIRBuilder: Buildable>
         let res = self.resolve(&mut ast, &cfg);
         debug_assert!(res.is_ok(), "{:?}", res.unwrap_err());
         log!(info "Dependency resolution process completed");
-        log!("graph:\n{}", self.shared.graph.display());
+        println!("graph:\n{}", self.shared.graph.display());
         if self.parse_errors.errors.is_empty() {
             self.shared.warns.extend(self.parse_errors.warns.flush());
         // continue analysis if ELS mode
@@ -838,9 +838,12 @@ impl<ASTBuilder: ASTBuildable, HIRBuilder: Buildable>
             write!(out, "Checking 0/{nmods}").unwrap();
             out.flush().unwrap();
         }
+        println!("here?: {path}");
+        let mut limit = 100000;
         while let Some(ancestor) = ancestors.pop() {
             if graph.ancestors(&ancestor).is_empty() {
                 graph.remove(&ancestor);
+                limit = 100000;
                 if let Some(entry) = self.asts.remove(&ancestor) {
                     if print_progress {
                         let name = ancestor.file_name().unwrap_or_default().to_string_lossy();
@@ -861,6 +864,10 @@ impl<ASTBuilder: ASTBuildable, HIRBuilder: Buildable>
                     self.build_inlined_module(&ancestor, graph);
                 }
             } else {
+                limit -= 1;
+                if limit == 0 {
+                    panic!("{ancestor} is in a circular dependency");
+                }
                 ancestors.insert(0, ancestor);
             }
         }
@@ -943,6 +950,7 @@ impl<ASTBuilder: ASTBuildable, HIRBuilder: Buildable>
                 }
             }
         };
+        println!("Start to analyze {path}");
         if SINGLE_THREAD {
             run();
             self.shared.promises.mark_as_joined(path);

--- a/crates/erg_compiler/context/compare.rs
+++ b/crates/erg_compiler/context/compare.rs
@@ -816,6 +816,7 @@ impl Context {
             }
             // Int or Str :> Str or Int == (Int :> Str && Str :> Int) || (Int :> Int && Str :> Str) == true
             // Int or Str or NoneType :> Str or Int
+            // Int or Str or NoneType :> Str or NoneType or Nat
             (Or(l), Or(r)) => r.iter().all(|r| l.iter().any(|l| self.supertype_of(l, r))),
             // not Nat :> not Int == true
             (Not(l), Not(r)) => self.subtype_of(l, r),

--- a/crates/erg_compiler/context/compare.rs
+++ b/crates/erg_compiler/context/compare.rs
@@ -1778,13 +1778,15 @@ impl Context {
     /// intersection_add(Int and ?T(:> NoneType), Str) == Never
     /// ```
     fn intersection_add(&self, intersection: &Type, elem: &Type) -> Type {
-        let ands = intersection.ands();
+        let mut ands = intersection.ands();
         let bounded = ands.iter().map(|t| t.lower_bounded());
         for t in bounded {
             if self.subtype_of(&t, elem) {
                 return intersection.clone();
             } else if self.supertype_of(&t, elem) {
-                return constructors::ands(ands.linear_exclude(&t).include(elem.clone()));
+                ands.retain(|ty| ty != &t);
+                ands.push(elem.clone());
+                return constructors::ands(ands);
             }
         }
         and(intersection.clone(), elem.clone())

--- a/crates/erg_compiler/context/eval.rs
+++ b/crates/erg_compiler/context/eval.rs
@@ -2285,44 +2285,42 @@ impl Context {
                     Err((t, errs))
                 }
             }
-            Type::And(l, r) => {
-                let l = match self.eval_t_params(*l, level, t_loc) {
-                    Ok(l) => l,
-                    Err((l, es)) => {
-                        errs.extend(es);
-                        l
+            Type::And(ands) => {
+                let mut new_ands = set! {};
+                for and in ands.into_iter() {
+                    match self.eval_t_params(and, level, t_loc) {
+                        Ok(and) => {
+                            new_ands.insert(and);
+                        }
+                        Err((and, es)) => {
+                            new_ands.insert(and);
+                            errs.extend(es);
+                        }
                     }
-                };
-                let r = match self.eval_t_params(*r, level, t_loc) {
-                    Ok(r) => r,
-                    Err((r, es)) => {
-                        errs.extend(es);
-                        r
-                    }
-                };
-                let intersec = self.intersection(&l, &r);
+                }
+                let intersec = new_ands
+                    .into_iter()
+                    .fold(Type::Obj, |l, r| self.intersection(&l, &r));
                 if errs.is_empty() {
                     Ok(intersec)
                 } else {
                     Err((intersec, errs))
                 }
             }
-            Type::Or(l, r) => {
-                let l = match self.eval_t_params(*l, level, t_loc) {
-                    Ok(l) => l,
-                    Err((l, es)) => {
-                        errs.extend(es);
-                        l
+            Type::Or(ors) => {
+                let mut new_ors = set! {};
+                for or in ors.into_iter() {
+                    match self.eval_t_params(or, level, t_loc) {
+                        Ok(or) => {
+                            new_ors.insert(or);
+                        }
+                        Err((or, es)) => {
+                            new_ors.insert(or);
+                            errs.extend(es);
+                        }
                     }
-                };
-                let r = match self.eval_t_params(*r, level, t_loc) {
-                    Ok(r) => r,
-                    Err((r, es)) => {
-                        errs.extend(es);
-                        r
-                    }
-                };
-                let union = self.union(&l, &r);
+                }
+                let union = new_ors.into_iter().fold(Never, |l, r| self.union(&l, &r));
                 if errs.is_empty() {
                     Ok(union)
                 } else {

--- a/crates/erg_compiler/context/hint.rs
+++ b/crates/erg_compiler/context/hint.rs
@@ -116,9 +116,12 @@ impl Context {
                     return Some(hint);
                 }
             }
-            (Type::And(l, r), found) => {
-                let left = self.readable_type(l.as_ref().clone());
-                let right = self.readable_type(r.as_ref().clone());
+            (Type::And(tys), found) if tys.len() == 2 => {
+                let mut iter = tys.iter();
+                let l = iter.next().unwrap();
+                let r = iter.next().unwrap();
+                let left = self.readable_type(l.clone());
+                let right = self.readable_type(r.clone());
                 if self.supertype_of(l, found) {
                     let msg = switch_lang!(
                         "japanese" => format!("型{found}は{left}のサブタイプですが、{right}のサブタイプではありません"),

--- a/crates/erg_compiler/context/initialize/traits.rs
+++ b/crates/erg_compiler/context/initialize/traits.rs
@@ -588,10 +588,10 @@ impl Context {
         neg.register_builtin_erg_decl(OP_NEG, op_t, Visibility::BUILTIN_PUBLIC);
         neg.register_builtin_erg_decl(OUTPUT, Type, Visibility::BUILTIN_PUBLIC);
         /* Num */
-        let mut num = Self::builtin_mono_trait(NUM, 2);
-        num.register_superclass(poly(ADD, vec![]), &add);
-        num.register_superclass(poly(SUB, vec![]), &sub);
-        num.register_superclass(poly(MUL, vec![]), &mul);
+        let num = Self::builtin_mono_trait(NUM, 2);
+        // num.register_superclass(poly(ADD, vec![]), &add);
+        // num.register_superclass(poly(SUB, vec![]), &sub);
+        // num.register_superclass(poly(MUL, vec![]), &mul);
         /* ToBool */
         let mut to_bool = Self::builtin_mono_trait(TO_BOOL, 2);
         let _Slf = mono_q(SELF, subtypeof(mono(TO_BOOL)));

--- a/crates/erg_compiler/context/inquire.rs
+++ b/crates/erg_compiler/context/inquire.rs
@@ -73,7 +73,7 @@ impl Context {
         }
         if self.shared.is_some() && self.promises().is_registered(&path) && !self.mod_cached(&path)
         {
-            let _result = self.promises().join(&path);
+            self.promises().join(&path).unwrap();
         }
         self.opt_mod_cache()?
             .raw_ref_ctx(&path)

--- a/crates/erg_compiler/context/inquire.rs
+++ b/crates/erg_compiler/context/inquire.rs
@@ -73,7 +73,7 @@ impl Context {
         }
         if self.shared.is_some() && self.promises().is_registered(&path) && !self.mod_cached(&path)
         {
-            self.promises().join(&path).unwrap();
+            let _result = self.promises().join(&path);
         }
         self.opt_mod_cache()?
             .raw_ref_ctx(&path)

--- a/crates/erg_compiler/context/unify.rs
+++ b/crates/erg_compiler/context/unify.rs
@@ -70,6 +70,7 @@ impl<'c, 'l, 'u, L: Locational> Unifier<'c, 'l, 'u, L> {
     /// occur(?T(<: Str) or ?U(<: Int), ?T(<: Str)) ==> Error
     /// occur(?T(<: ?U or Y), ?U) ==> OK
     /// occur(?T, ?T.Output) ==> OK
+    /// occur(?T, ?T or Int) ==> Error
     /// ```
     fn occur(&self, maybe_sub: &Type, maybe_sup: &Type) -> TyCheckResult<()> {
         if maybe_sub == maybe_sup {
@@ -160,7 +161,7 @@ impl<'c, 'l, 'u, L: Locational> Unifier<'c, 'l, 'u, L> {
                 for _ in 0..r.len() {
                     if l.iter()
                         .zip(r.iter())
-                        .all(|(l, r)| self.occur(l, r).is_ok())
+                        .all(|(l, r)| self.occur_inner(l, r).is_ok())
                     {
                         return Ok(());
                     }
@@ -181,7 +182,7 @@ impl<'c, 'l, 'u, L: Locational> Unifier<'c, 'l, 'u, L> {
                 for _ in 0..r.len() {
                     if l.iter()
                         .zip(r.iter())
-                        .all(|(l, r)| self.occur(l, r).is_ok())
+                        .all(|(l, r)| self.occur_inner(l, r).is_ok())
                     {
                         return Ok(());
                     }
@@ -198,25 +199,25 @@ impl<'c, 'l, 'u, L: Locational> Unifier<'c, 'l, 'u, L> {
             }
             (lhs, And(tys)) => {
                 for ty in tys.iter() {
-                    self.occur(lhs, ty)?;
+                    self.occur_inner(lhs, ty)?;
                 }
                 Ok(())
             }
             (lhs, Or(tys)) => {
                 for ty in tys.iter() {
-                    self.occur(lhs, ty)?;
+                    self.occur_inner(lhs, ty)?;
                 }
                 Ok(())
             }
             (And(tys), rhs) => {
                 for ty in tys.iter() {
-                    self.occur(ty, rhs)?;
+                    self.occur_inner(ty, rhs)?;
                 }
                 Ok(())
             }
             (Or(tys), rhs) => {
                 for ty in tys.iter() {
-                    self.occur(ty, rhs)?;
+                    self.occur_inner(ty, rhs)?;
                 }
                 Ok(())
             }

--- a/crates/erg_compiler/lower.rs
+++ b/crates/erg_compiler/lower.rs
@@ -362,10 +362,9 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
         }
     }
 
-    fn elem_err(&self, l: &Type, r: &Type, elem: &hir::Expr) -> LowerErrors {
+    fn elem_err(&self, union: Type, elem: &hir::Expr) -> LowerErrors {
         let elem_disp_notype = elem.to_string_notype();
-        let l = self.module.context.readable_type(l.clone());
-        let r = self.module.context.readable_type(r.clone());
+        let union = self.module.context.readable_type(union);
         LowerErrors::from(LowerError::syntax_error(
             self.cfg.input.clone(),
             line!() as usize,
@@ -379,10 +378,10 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
             )
             .to_owned(),
             Some(switch_lang!(
-                "japanese" => format!("[..., {elem_disp_notype}: {l} or {r}]など明示的に型を指定してください"),
-                "simplified_chinese" => format!("请明确指定类型，例如: [..., {elem_disp_notype}: {l} or {r}]"),
-                "traditional_chinese" => format!("請明確指定類型，例如: [..., {elem_disp_notype}: {l} or {r}]"),
-                "english" => format!("please specify the type explicitly, e.g. [..., {elem_disp_notype}: {l} or {r}]"),
+                "japanese" => format!("[..., {elem_disp_notype}: {union}]など明示的に型を指定してください"),
+                "simplified_chinese" => format!("请明确指定类型，例如: [..., {elem_disp_notype}: {union}]"),
+                "traditional_chinese" => format!("請明確指定類型，例如: [..., {elem_disp_notype}: {union}]"),
+                "english" => format!("please specify the type explicitly, e.g. [..., {elem_disp_notype}: {union}]"),
             )),
         ))
     }
@@ -453,36 +452,25 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
         union: &Type,
         elem: &hir::Expr,
     ) -> LowerResult<()> {
-        if ERG_MODE && expect_elem.is_none() {
-            if let Some((l, r)) = union_.union_pair() {
-                match (l.is_unbound_var(), r.is_unbound_var()) {
-                    // e.g. [1, "a"]
-                    (false, false) => {
-                        if let hir::Expr::TypeAsc(type_asc) = elem {
-                            // e.g. [1, "a": Str or NoneType]
-                            if !self
-                                .module
-                                .context
-                                .supertype_of(&type_asc.spec.spec_t, union)
-                            {
-                                return Err(self.elem_err(&l, &r, elem));
-                            } // else(OK): e.g. [1, "a": Str or Int]
-                        }
-                        // OK: ?T(:> {"a"}) or ?U(:> {"b"}) or {"c", "d"} => {"a", "b", "c", "d"} <: Str
-                        else if self
-                            .module
-                            .context
-                            .coerce(union_.derefine(), &())
-                            .map_or(true, |coerced| coerced.union_pair().is_some())
-                        {
-                            return Err(self.elem_err(&l, &r, elem));
-                        }
-                    }
-                    // TODO: check if the type is compatible with the other type
-                    (true, false) => {}
-                    (false, true) => {}
-                    (true, true) => {}
-                }
+        if ERG_MODE && expect_elem.is_none() && union_.union_size() > 1 {
+            if let hir::Expr::TypeAsc(type_asc) = elem {
+                // e.g. [1, "a": Str or NoneType]
+                if !self
+                    .module
+                    .context
+                    .supertype_of(&type_asc.spec.spec_t, union)
+                {
+                    return Err(self.elem_err(union_.clone(), elem));
+                } // else(OK): e.g. [1, "a": Str or Int]
+            }
+            // OK: ?T(:> {"a"}) or ?U(:> {"b"}) or {"c", "d"} => {"a", "b", "c", "d"} <: Str
+            else if self
+                .module
+                .context
+                .coerce(union_.derefine(), &())
+                .map_or(true, |coerced| coerced.union_pair().is_some())
+            {
+                return Err(self.elem_err(union_.clone(), elem));
             }
         }
         Ok(())

--- a/crates/erg_compiler/lower.rs
+++ b/crates/erg_compiler/lower.rs
@@ -1502,9 +1502,10 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
                 }
                 _ => {}
             },
-            Type::And(lhs, rhs) => {
-                self.push_guard(nth, kind, lhs);
-                self.push_guard(nth, kind, rhs);
+            Type::And(tys) => {
+                for ty in tys {
+                    self.push_guard(nth, kind, ty);
+                }
             }
             _ => {}
         }

--- a/crates/erg_compiler/module/cache.rs
+++ b/crates/erg_compiler/module/cache.rs
@@ -340,6 +340,7 @@ impl SharedModuleCache {
     where
         NormalizedPathBuf: Borrow<Q>,
     {
+        println!("343");
         let mut cache = loop {
             if let Some(cache) = self.0.try_borrow_mut() {
                 break cache;

--- a/crates/erg_compiler/module/cache.rs
+++ b/crates/erg_compiler/module/cache.rs
@@ -340,7 +340,6 @@ impl SharedModuleCache {
     where
         NormalizedPathBuf: Borrow<Q>,
     {
-        println!("343");
         let mut cache = loop {
             if let Some(cache) = self.0.try_borrow_mut() {
                 break cache;

--- a/crates/erg_compiler/module/promise.rs
+++ b/crates/erg_compiler/module/promise.rs
@@ -160,6 +160,7 @@ impl SharedPromises {
     }
 
     pub fn wait_until_finished(&self, path: &NormalizedPathBuf) {
+        println!("163");
         if self.promises.borrow().get(path).is_none() {
             panic!("not registered: {path}");
         }
@@ -179,9 +180,11 @@ impl SharedPromises {
             return Ok(());
         }
         if SINGLE_THREAD {
+            println!("182: {path}");
             assert!(self.is_joined(path));
             return Ok(());
         }
+        println!("!?: {path}");
         // Suppose A depends on B and C, and B depends on C.
         // In this case, B must join C before A joins C. Otherwise, a deadlock will occur.
         let children = self.graph.children(path);
@@ -223,14 +226,14 @@ impl SharedPromises {
             paths.push(path.clone());
         }
         for path in paths {
-            let _result = self.join(&path);
+            self.join(&path).unwrap();
         }
     }
 
     pub fn join_all(&self) {
         let paths = self.promises.borrow().keys().cloned().collect::<Vec<_>>();
         for path in paths {
-            let _result = self.join(&path);
+            self.join(&path).unwrap();
         }
     }
 

--- a/crates/erg_compiler/module/promise.rs
+++ b/crates/erg_compiler/module/promise.rs
@@ -160,7 +160,6 @@ impl SharedPromises {
     }
 
     pub fn wait_until_finished(&self, path: &NormalizedPathBuf) {
-        println!("163");
         if self.promises.borrow().get(path).is_none() {
             panic!("not registered: {path}");
         }
@@ -180,11 +179,9 @@ impl SharedPromises {
             return Ok(());
         }
         if SINGLE_THREAD {
-            println!("182: {path}");
             assert!(self.is_joined(path));
             return Ok(());
         }
-        println!("!?: {path}");
         // Suppose A depends on B and C, and B depends on C.
         // In this case, B must join C before A joins C. Otherwise, a deadlock will occur.
         let children = self.graph.children(path);
@@ -226,14 +223,14 @@ impl SharedPromises {
             paths.push(path.clone());
         }
         for path in paths {
-            self.join(&path).unwrap();
+            let _result = self.join(&path);
         }
     }
 
     pub fn join_all(&self) {
         let paths = self.promises.borrow().keys().cloned().collect::<Vec<_>>();
         for path in paths {
-            self.join(&path).unwrap();
+            let _result = self.join(&path);
         }
     }
 

--- a/crates/erg_compiler/ty/constructors.rs
+++ b/crates/erg_compiler/ty/constructors.rs
@@ -593,35 +593,11 @@ pub fn refinement(var: Str, t: Type, pred: Predicate) -> Type {
 }
 
 pub fn and(lhs: Type, rhs: Type) -> Type {
-    match (lhs, rhs) {
-        (Type::And(l, r), other) | (other, Type::And(l, r)) => {
-            if l.as_ref() == &other {
-                and(*r, other)
-            } else if r.as_ref() == &other {
-                and(*l, other)
-            } else {
-                Type::And(Box::new(Type::And(l, r)), Box::new(other))
-            }
-        }
-        (Type::Obj, other) | (other, Type::Obj) => other,
-        (lhs, rhs) => Type::And(Box::new(lhs), Box::new(rhs)),
-    }
+    lhs & rhs
 }
 
 pub fn or(lhs: Type, rhs: Type) -> Type {
-    match (lhs, rhs) {
-        (Type::Or(l, r), other) | (other, Type::Or(l, r)) => {
-            if l.as_ref() == &other {
-                or(*r, other)
-            } else if r.as_ref() == &other {
-                or(*l, other)
-            } else {
-                Type::Or(Box::new(Type::Or(l, r)), Box::new(other))
-            }
-        }
-        (Type::Never, other) | (other, Type::Never) => other,
-        (lhs, rhs) => Type::Or(Box::new(lhs), Box::new(rhs)),
-    }
+    lhs | rhs
 }
 
 pub fn ors(tys: impl IntoIterator<Item = Type>) -> Type {

--- a/crates/erg_compiler/ty/free.rs
+++ b/crates/erg_compiler/ty/free.rs
@@ -774,7 +774,12 @@ impl Free<Type> {
         let placeholder = placeholder.unwrap_or(&Type::Failure);
         let is_recursive = self.is_recursive();
         if is_recursive {
-            self.undoable_link(placeholder);
+            let target = Type::FreeVar(self.clone());
+            let placeholder_ = placeholder
+                .clone()
+                .eliminate_subsup(&target)
+                .eliminate_and_or_recursion(&target);
+            self.undoable_link(&placeholder_);
         }
         let res = f();
         if is_recursive {
@@ -884,7 +889,9 @@ impl Free<TyParam> {
         let placeholder = placeholder.unwrap_or(&TyParam::Failure);
         let is_recursive = self.is_recursive();
         if is_recursive {
-            self.undoable_link(placeholder);
+            let target = TyParam::FreeVar(self.clone());
+            let placeholder_ = placeholder.clone().eliminate_recursion(&target);
+            self.undoable_link(&placeholder_);
         }
         let res = f();
         if is_recursive {

--- a/crates/erg_compiler/ty/mod.rs
+++ b/crates/erg_compiler/ty/mod.rs
@@ -1956,7 +1956,6 @@ impl HasType for Type {
 
 impl HasLevel for Type {
     fn level(&self) -> Option<usize> {
-        println!("lev: {self}");
         match self {
             Self::FreeVar(v) => v.level(),
             Self::Ref(t) => t.level(),
@@ -2035,10 +2034,7 @@ impl HasLevel for Type {
                     Some(min)
                 }
             }
-            Self::Structural(ty) => {
-                set_recursion_limit!(None, 128);
-                ty.level()
-            }
+            Self::Structural(ty) => ty.level(),
             Self::Guard(guard) => guard.to.level(),
             Self::Quantified(quant) => quant.level(),
             Self::Bounded { sub, sup } => {

--- a/crates/erg_compiler/ty/mod.rs
+++ b/crates/erg_compiler/ty/mod.rs
@@ -1410,8 +1410,8 @@ pub enum Type {
     Refinement(RefinementType),
     // e.g. |T: Type| T -> T
     Quantified(Box<Type>),
-    And(Box<Type>, Box<Type>),
-    Or(Box<Type>, Box<Type>),
+    And(Set<Type>),
+    Or(Set<Type>),
     Not(Box<Type>),
     // NOTE: It was found that adding a new variant above `Poly` may cause a subtyping bug,
     // possibly related to enum internal numbering, but the cause is unknown.
@@ -1504,8 +1504,8 @@ impl PartialEq for Type {
             (Self::NamedTuple(lhs), Self::NamedTuple(rhs)) => lhs == rhs,
             (Self::Refinement(l), Self::Refinement(r)) => l == r,
             (Self::Quantified(l), Self::Quantified(r)) => l == r,
-            (Self::And(_, _), Self::And(_, _)) => self.ands().linear_eq(&other.ands()),
-            (Self::Or(_, _), Self::Or(_, _)) => self.ors().linear_eq(&other.ors()),
+            (Self::And(l), Self::And(r)) => l.linear_eq(r),
+            (Self::Or(l), Self::Or(r)) => l.linear_eq(r),
             (Self::Not(l), Self::Not(r)) => l == r,
             (
                 Self::Poly {
@@ -1659,19 +1659,27 @@ impl LimitedDisplay for Type {
                 write!(f, "|")?;
                 quantified.limited_fmt(f, limit - 1)
             }
-            Self::And(lhs, rhs) => {
-                lhs.limited_fmt(f, limit - 1)?;
-                write!(f, " and ")?;
-                rhs.limited_fmt(f, limit - 1)
+            Self::And(ands) => {
+                for (i, ty) in ands.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, " and ")?;
+                    }
+                    ty.limited_fmt(f, limit - 1)?;
+                }
+                Ok(())
+            }
+            Self::Or(ors) => {
+                for (i, ty) in ors.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, " or ")?;
+                    }
+                    ty.limited_fmt(f, limit - 1)?;
+                }
+                Ok(())
             }
             Self::Not(ty) => {
                 write!(f, "not ")?;
                 ty.limited_fmt(f, limit - 1)
-            }
-            Self::Or(lhs, rhs) => {
-                lhs.limited_fmt(f, limit - 1)?;
-                write!(f, " or ")?;
-                rhs.limited_fmt(f, limit - 1)
             }
             Self::Poly { name, params } => {
                 write!(f, "{name}(")?;
@@ -1852,14 +1860,40 @@ impl From<Dict<Field, Type>> for Type {
 impl BitAnd for Type {
     type Output = Self;
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self::And(Box::new(self), Box::new(rhs))
+        match (self, rhs) {
+            (Self::And(l), Self::And(r)) => Self::And(l.union(&r)),
+            (Self::Obj, other) | (other, Self::Obj) => other,
+            (Self::Never, _) | (_, Self::Never) => Self::Never,
+            (Self::And(mut l), r) => {
+                l.insert(r);
+                Self::And(l)
+            }
+            (l, Self::And(mut r)) => {
+                r.insert(l);
+                Self::And(r)
+            }
+            (l, r) => Self::checked_and(set! {l, r}),
+        }
     }
 }
 
 impl BitOr for Type {
     type Output = Self;
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self::Or(Box::new(self), Box::new(rhs))
+        match (self, rhs) {
+            (Self::Or(l), Self::Or(r)) => Self::Or(l.union(&r)),
+            (Self::Obj, _) | (_, Self::Obj) => Self::Obj,
+            (Self::Never, other) | (other, Self::Never) => other,
+            (Self::Or(mut l), r) => {
+                l.insert(r);
+                Self::Or(l)
+            }
+            (l, Self::Or(mut r)) => {
+                r.insert(l);
+                Self::Or(r)
+            }
+            (l, r) => Self::checked_or(set! {l, r}),
+        }
     }
 }
 
@@ -1974,17 +2008,7 @@ impl HasLevel for Type {
                     .filter_map(|o| *o)
                     .min()
             }
-            Self::And(lhs, rhs) | Self::Or(lhs, rhs) => {
-                let l = lhs
-                    .level()
-                    .unwrap_or(GENERIC_LEVEL)
-                    .min(rhs.level().unwrap_or(GENERIC_LEVEL));
-                if l == GENERIC_LEVEL {
-                    None
-                } else {
-                    Some(l)
-                }
-            }
+            Self::And(tys) | Self::Or(tys) => tys.iter().filter_map(|t| t.level()).min(),
             Self::Not(ty) => ty.level(),
             Self::Record(attrs) => attrs.values().filter_map(|t| t.level()).min(),
             Self::NamedTuple(attrs) => attrs.iter().filter_map(|(_, t)| t.level()).min(),
@@ -2065,9 +2089,10 @@ impl HasLevel for Type {
             Self::Quantified(quant) => {
                 quant.set_level(level);
             }
-            Self::And(lhs, rhs) | Self::Or(lhs, rhs) => {
-                lhs.set_level(level);
-                rhs.set_level(level);
+            Self::And(tys) | Self::Or(tys) => {
+                for t in tys.iter() {
+                    t.set_level(level);
+                }
             }
             Self::Not(ty) => ty.set_level(level),
             Self::Record(attrs) => {
@@ -2218,9 +2243,7 @@ impl StructuralEq for Type {
             (Self::Guard(l), Self::Guard(r)) => l.structural_eq(r),
             // NG: (l.structural_eq(l2) && r.structural_eq(r2))
             //     || (l.structural_eq(r2) && r.structural_eq(l2))
-            (Self::And(_, _), Self::And(_, _)) => {
-                let self_ands = self.ands();
-                let other_ands = other.ands();
+            (Self::And(self_ands), Self::And(other_ands)) => {
                 if self_ands.len() != other_ands.len() {
                     return false;
                 }
@@ -2234,9 +2257,7 @@ impl StructuralEq for Type {
                 }
                 true
             }
-            (Self::Or(_, _), Self::Or(_, _)) => {
-                let self_ors = self.ors();
-                let other_ors = other.ors();
+            (Self::Or(self_ors), Self::Or(other_ors)) => {
                 if self_ors.len() != other_ors.len() {
                     return false;
                 }
@@ -2330,10 +2351,30 @@ impl Type {
         }
     }
 
+    pub fn checked_or(tys: Set<Type>) -> Self {
+        if tys.is_empty() {
+            panic!("tys is empty");
+        } else if tys.len() == 1 {
+            tys.into_iter().next().unwrap()
+        } else {
+            Self::Or(tys)
+        }
+    }
+
+    pub fn checked_and(tys: Set<Type>) -> Self {
+        if tys.is_empty() {
+            panic!("tys is empty");
+        } else if tys.len() == 1 {
+            tys.into_iter().next().unwrap()
+        } else {
+            Self::And(tys)
+        }
+    }
+
     pub fn quantify(self) -> Self {
         debug_assert!(self.is_subr(), "{self} is not subr");
         match self {
-            Self::And(lhs, rhs) => lhs.quantify() & rhs.quantify(),
+            Self::And(tys) => Self::And(tys.into_iter().map(|t| t.quantify()).collect()),
             other => Self::Quantified(Box::new(other)),
         }
     }
@@ -2431,7 +2472,7 @@ impl Type {
             Self::Quantified(t) => t.is_procedure(),
             Self::Subr(subr) if subr.kind == SubrKind::Proc => true,
             Self::Refinement(refine) => refine.t.is_procedure(),
-            Self::And(lhs, rhs) => lhs.is_procedure() && rhs.is_procedure(),
+            Self::And(tys) => tys.iter().any(|t| t.is_procedure()),
             _ => false,
         }
     }
@@ -2449,6 +2490,7 @@ impl Type {
                 name.ends_with('!')
             }
             Self::Refinement(refine) => refine.t.is_mut_type(),
+            Self::And(tys) => tys.iter().any(|t| t.is_mut_type()),
             _ => false,
         }
     }
@@ -2467,6 +2509,7 @@ impl Type {
             Self::Poly { name, params, .. } if &name[..] == "Tuple" => params.is_empty(),
             Self::Refinement(refine) => refine.t.is_nonelike(),
             Self::Bounded { sup, .. } => sup.is_nonelike(),
+            Self::And(tys) => tys.iter().any(|t| t.is_nonelike()),
             _ => false,
         }
     }
@@ -2516,7 +2559,7 @@ impl Type {
     pub fn is_union_type(&self) -> bool {
         match self {
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().is_union_type(),
-            Self::Or(_, _) => true,
+            Self::Or(_) => true,
             Self::Refinement(refine) => refine.t.is_union_type(),
             _ => false,
         }
@@ -2549,7 +2592,7 @@ impl Type {
     pub fn is_intersection_type(&self) -> bool {
         match self {
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().is_intersection_type(),
-            Self::And(_, _) => true,
+            Self::And(_) => true,
             Self::Refinement(refine) => refine.t.is_intersection_type(),
             _ => false,
         }
@@ -2563,11 +2606,11 @@ impl Type {
                 fv.do_avoiding_recursion(|| sub.union_size().max(sup.union_size()))
             }
             // Or(Or(Int, Str), Nat) == 3
-            Self::Or(l, r) => l.union_size() + r.union_size(),
+            Self::Or(tys) => tys.len(),
             Self::Refinement(refine) => refine.t.union_size(),
             Self::Ref(t) => t.union_size(),
             Self::RefMut { before, after: _ } => before.union_size(),
-            Self::And(lhs, rhs) => lhs.union_size().max(rhs.union_size()),
+            Self::And(tys) => tys.iter().map(|ty| ty.union_size()).max().unwrap_or(1),
             Self::Not(ty) => ty.union_size(),
             Self::Callable { param_ts, return_t } => param_ts
                 .iter()
@@ -2608,7 +2651,7 @@ impl Type {
         match self {
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().is_refinement(),
             Self::Refinement(_) => true,
-            Self::And(l, r) => l.is_refinement() && r.is_refinement(),
+            Self::And(tys) => tys.iter().any(|t| t.is_refinement()),
             _ => false,
         }
     }
@@ -2617,6 +2660,7 @@ impl Type {
         match self {
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().is_singleton_refinement(),
             Self::Refinement(refine) => matches!(refine.pred.as_ref(), Predicate::Equal { .. }),
+            Self::And(tys) => tys.iter().any(|t| t.is_singleton_refinement()),
             _ => false,
         }
     }
@@ -2626,6 +2670,7 @@ impl Type {
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().is_record(),
             Self::Record(_) => true,
             Self::Refinement(refine) => refine.t.is_record(),
+            Self::And(tys) => tys.iter().any(|t| t.is_record()),
             _ => false,
         }
     }
@@ -2639,6 +2684,7 @@ impl Type {
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().is_erg_module(),
             Self::Refinement(refine) => refine.t.is_erg_module(),
             Self::Poly { name, .. } => &name[..] == "Module",
+            Self::And(tys) => tys.iter().any(|t| t.is_erg_module()),
             _ => false,
         }
     }
@@ -2648,6 +2694,7 @@ impl Type {
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().is_py_module(),
             Self::Refinement(refine) => refine.t.is_py_module(),
             Self::Poly { name, .. } => &name[..] == "PyModule",
+            Self::And(tys) => tys.iter().any(|t| t.is_py_module()),
             _ => false,
         }
     }
@@ -2658,7 +2705,7 @@ impl Type {
             Self::Refinement(refine) => refine.t.is_method(),
             Self::Subr(subr) => subr.is_method(),
             Self::Quantified(quant) => quant.is_method(),
-            Self::And(l, r) => l.is_method() && r.is_method(),
+            Self::And(tys) => tys.iter().any(|t| t.is_method()),
             _ => false,
         }
     }
@@ -2669,7 +2716,7 @@ impl Type {
             Self::Subr(_) => true,
             Self::Quantified(quant) => quant.is_subr(),
             Self::Refinement(refine) => refine.t.is_subr(),
-            Self::And(l, r) => l.is_subr() && r.is_subr(),
+            Self::And(tys) => tys.iter().any(|t| t.is_subr()),
             _ => false,
         }
     }
@@ -2680,7 +2727,10 @@ impl Type {
             Self::Subr(subr) => Some(subr.kind),
             Self::Refinement(refine) => refine.t.subr_kind(),
             Self::Quantified(quant) => quant.subr_kind(),
-            Self::And(l, r) => l.subr_kind().and_then(|k| r.subr_kind().map(|k2| k | k2)),
+            Self::And(tys) => tys
+                .iter()
+                .filter_map(|t| t.subr_kind())
+                .fold(None, |a, b| Some(a? | b)),
             _ => None,
         }
     }
@@ -2690,7 +2740,7 @@ impl Type {
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().is_quantified_subr(),
             Self::Quantified(_) => true,
             Self::Refinement(refine) => refine.t.is_quantified_subr(),
-            Self::And(l, r) => l.is_quantified_subr() && r.is_quantified_subr(),
+            Self::And(tys) => tys.iter().any(|t| t.is_quantified_subr()),
             _ => false,
         }
     }
@@ -2727,6 +2777,7 @@ impl Type {
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().is_iterable(),
             Self::Poly { name, .. } => &name[..] == "Iterable",
             Self::Refinement(refine) => refine.t.is_iterable(),
+            Self::And(tys) => tys.iter().any(|t| t.is_iterable()),
             _ => false,
         }
     }
@@ -2817,6 +2868,7 @@ impl Type {
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().is_structural(),
             Self::Structural(_) => true,
             Self::Refinement(refine) => refine.t.is_structural(),
+            Self::And(tys) => tys.iter().any(|t| t.is_structural()),
             _ => false,
         }
     }
@@ -2826,6 +2878,7 @@ impl Type {
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().is_failure(),
             Self::Refinement(refine) => refine.t.is_failure(),
             Self::Failure => true,
+            Self::And(tys) => tys.iter().any(|t| t.is_failure()),
             _ => false,
         }
     }
@@ -2902,8 +2955,8 @@ impl Type {
             Self::ProjCall { lhs, args, .. } => {
                 lhs.contains_tvar(target) || args.iter().any(|t| t.contains_tvar(target))
             }
-            Self::And(lhs, rhs) => lhs.contains_tvar(target) || rhs.contains_tvar(target),
-            Self::Or(lhs, rhs) => lhs.contains_tvar(target) || rhs.contains_tvar(target),
+            Self::And(tys) => tys.iter().any(|t| t.contains_tvar(target)),
+            Self::Or(tys) => tys.iter().any(|t| t.contains_tvar(target)),
             Self::Not(t) => t.contains_tvar(target),
             Self::Ref(t) => t.contains_tvar(target),
             Self::RefMut { before, after } => {
@@ -2962,8 +3015,8 @@ impl Type {
             Self::ProjCall { lhs, args, .. } => {
                 lhs.has_type_satisfies(f) || args.iter().any(|t| t.has_type_satisfies(f))
             }
-            Self::And(lhs, rhs) | Self::Or(lhs, rhs) => {
-                lhs.has_type_satisfies(f) || rhs.has_type_satisfies(f)
+            Self::And(tys) | Self::Or(tys) => {
+                tys.iter().any(|t| t.has_type_satisfies(f))
             }
             Self::Not(t) => t.has_type_satisfies(f),
             Self::Ref(t) => t.has_type_satisfies(f),
@@ -3030,8 +3083,8 @@ impl Type {
             Self::ProjCall { lhs, args, .. } => {
                 lhs.contains_type(target) || args.iter().any(|t| t.contains_type(target))
             }
-            Self::And(lhs, rhs) => lhs.contains_type(target) || rhs.contains_type(target),
-            Self::Or(lhs, rhs) => lhs.contains_type(target) || rhs.contains_type(target),
+            Self::And(tys) => tys.iter().any(|t| t.contains_type(target)),
+            Self::Or(tys) => tys.iter().any(|t| t.contains_type(target)),
             Self::Not(t) => t.contains_type(target),
             Self::Ref(t) => t.contains_type(target),
             Self::RefMut { before, after } => {
@@ -3068,8 +3121,8 @@ impl Type {
             Self::ProjCall { lhs, args, .. } => {
                 lhs.contains_tp(target) || args.iter().any(|t| t.contains_tp(target))
             }
-            Self::And(lhs, rhs) => lhs.contains_tp(target) || rhs.contains_tp(target),
-            Self::Or(lhs, rhs) => lhs.contains_tp(target) || rhs.contains_tp(target),
+            Self::And(tys) => tys.iter().any(|t| t.contains_tp(target)),
+            Self::Or(tys) => tys.iter().any(|t| t.contains_tp(target)),
             Self::Not(t) => t.contains_tp(target),
             Self::Ref(t) => t.contains_tp(target),
             Self::RefMut { before, after } => {
@@ -3102,8 +3155,8 @@ impl Type {
             Self::ProjCall { lhs, args, .. } => {
                 lhs.contains_value(target) || args.iter().any(|t| t.contains_value(target))
             }
-            Self::And(lhs, rhs) => lhs.contains_value(target) || rhs.contains_value(target),
-            Self::Or(lhs, rhs) => lhs.contains_value(target) || rhs.contains_value(target),
+            Self::And(tys) => tys.iter().any(|t| t.contains_value(target)),
+            Self::Or(tys) => tys.iter().any(|t| t.contains_value(target)),
             Self::Not(t) => t.contains_value(target),
             Self::Ref(t) => t.contains_value(target),
             Self::RefMut { before, after } => {
@@ -3146,9 +3199,7 @@ impl Type {
             Self::ProjCall { lhs, args, .. } => {
                 lhs.contains_type(self) || args.iter().any(|t| t.contains_type(self))
             }
-            Self::And(lhs, rhs) | Self::Or(lhs, rhs) => {
-                lhs.contains_type(self) || rhs.contains_type(self)
-            }
+            Self::And(tys) | Self::Or(tys) => tys.iter().any(|t| t.contains_type(self)),
             Self::Not(t) => t.contains_type(self),
             Self::Ref(t) => t.contains_type(self),
             Self::RefMut { before, after } => {
@@ -3218,9 +3269,9 @@ impl Type {
             Self::Inf => Str::ever("Inf"),
             Self::NegInf => Str::ever("NegInf"),
             Self::Mono(name) => name.clone(),
-            Self::And(_, _) => Str::ever("And"),
+            Self::And(_) => Str::ever("And"),
             Self::Not(_) => Str::ever("Not"),
-            Self::Or(_, _) => Str::ever("Or"),
+            Self::Or(_) => Str::ever("Or"),
             Self::Ref(_) => Str::ever("Ref"),
             Self::RefMut { .. } => Str::ever("RefMut"),
             Self::Subr(SubrType {
@@ -3310,7 +3361,7 @@ impl Type {
         match self {
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().contains_intersec(typ),
             Self::Refinement(refine) => refine.t.contains_intersec(typ),
-            Self::And(t1, t2) => t1.contains_intersec(typ) || t2.contains_intersec(typ),
+            Self::And(tys) => tys.iter().any(|t| t.contains_intersec(typ)),
             _ => self == typ,
         }
     }
@@ -3319,7 +3370,16 @@ impl Type {
         match self {
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().union_pair(),
             Self::Refinement(refine) => refine.t.union_pair(),
-            Self::Or(t1, t2) => Some((*t1.clone(), *t2.clone())),
+            Self::Or(tys) if tys.len() == 2 => {
+                let mut iter = tys.iter();
+                Some((iter.next().unwrap().clone(), iter.next().unwrap().clone()))
+            }
+            Self::Or(tys) => {
+                let mut iter = tys.iter();
+                let t1 = iter.next().unwrap().clone();
+                let t2 = iter.cloned().collect();
+                Some((t1, Type::Or(t2)))
+            }
             _ => None,
         }
     }
@@ -3329,7 +3389,7 @@ impl Type {
         match self {
             Type::FreeVar(fv) if fv.is_linked() => fv.crack().contains_union(typ),
             Type::Refinement(refine) => refine.t.contains_union(typ),
-            Type::Or(t1, t2) => t1.contains_union(typ) || t2.contains_union(typ),
+            Type::Or(tys) => tys.iter().any(|t| t.contains_union(typ)),
             _ => self == typ,
         }
     }
@@ -3343,11 +3403,7 @@ impl Type {
                 .into_iter()
                 .map(|t| t.quantify())
                 .collect(),
-            Type::And(t1, t2) => {
-                let mut types = t1.intersection_types();
-                types.extend(t2.intersection_types());
-                types
-            }
+            Type::And(tys) => tys.iter().cloned().collect(),
             _ => vec![self.clone()],
         }
     }
@@ -3423,9 +3479,7 @@ impl Type {
         match self {
             Self::FreeVar(fv) if fv.is_unbound() => true,
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().is_totally_unbound(),
-            Self::Or(t1, t2) | Self::And(t1, t2) => {
-                t1.is_totally_unbound() && t2.is_totally_unbound()
-            }
+            Self::Or(tys) | Self::And(tys) => tys.iter().all(|t| t.is_totally_unbound()),
             Self::Not(t) => t.is_totally_unbound(),
             _ => false,
         }
@@ -3532,9 +3586,10 @@ impl Type {
                 sub.destructive_coerce();
                 self.destructive_link(&sub);
             }
-            Type::And(l, r) | Type::Or(l, r) => {
-                l.destructive_coerce();
-                r.destructive_coerce();
+            Type::And(tys) | Type::Or(tys) => {
+                for t in tys {
+                    t.destructive_coerce();
+                }
             }
             Type::Not(l) => l.destructive_coerce(),
             Type::Poly { params, .. } => {
@@ -3587,9 +3642,10 @@ impl Type {
                 sub.undoable_coerce(list);
                 self.undoable_link(&sub, list);
             }
-            Type::And(l, r) | Type::Or(l, r) => {
-                l.undoable_coerce(list);
-                r.undoable_coerce(list);
+            Type::And(tys) | Type::Or(tys) => {
+                for t in tys {
+                    t.undoable_coerce(list);
+                }
             }
             Type::Not(l) => l.undoable_coerce(list),
             Type::Poly { params, .. } => {
@@ -3648,7 +3704,9 @@ impl Type {
                     .map(|t| t.qvars_inner())
                     .unwrap_or_else(|| set! {}),
             ),
-            Self::And(lhs, rhs) | Self::Or(lhs, rhs) => lhs.qvars_inner().concat(rhs.qvars_inner()),
+            Self::And(tys) | Self::Or(tys) => tys
+                .iter()
+                .fold(set! {}, |acc, t| acc.concat(t.qvars_inner())),
             Self::Not(ty) => ty.qvars_inner(),
             Self::Callable { param_ts, return_t } => param_ts
                 .iter()
@@ -3716,7 +3774,7 @@ impl Type {
             Self::RefMut { before, after } => {
                 before.has_qvar() || after.as_ref().map(|t| t.has_qvar()).unwrap_or(false)
             }
-            Self::And(lhs, rhs) | Self::Or(lhs, rhs) => lhs.has_qvar() || rhs.has_qvar(),
+            Self::And(tys) | Self::Or(tys) => tys.iter().any(|t| t.has_qvar()),
             Self::Not(ty) => ty.has_qvar(),
             Self::Callable { param_ts, return_t } => {
                 param_ts.iter().any(|t| t.has_qvar()) || return_t.has_qvar()
@@ -3769,9 +3827,7 @@ impl Type {
                         .map(|t| t.has_undoable_linked_var())
                         .unwrap_or(false)
             }
-            Self::And(lhs, rhs) | Self::Or(lhs, rhs) => {
-                lhs.has_undoable_linked_var() || rhs.has_undoable_linked_var()
-            }
+            Self::And(tys) | Self::Or(tys) => tys.iter().any(|t| t.has_undoable_linked_var()),
             Self::Not(ty) => ty.has_undoable_linked_var(),
             Self::Callable { param_ts, return_t } => {
                 param_ts.iter().any(|t| t.has_undoable_linked_var())
@@ -3810,9 +3866,7 @@ impl Type {
                 before.has_unbound_var()
                     || after.as_ref().map(|t| t.has_unbound_var()).unwrap_or(false)
             }
-            Self::And(lhs, rhs) | Self::Or(lhs, rhs) => {
-                lhs.has_unbound_var() || rhs.has_unbound_var()
-            }
+            Self::And(tys) | Self::Or(tys) => tys.iter().any(|t| t.has_unbound_var()),
             Self::Not(ty) => ty.has_unbound_var(),
             Self::Callable { param_ts, return_t } => {
                 param_ts.iter().any(|t| t.has_unbound_var()) || return_t.has_unbound_var()
@@ -3867,7 +3921,7 @@ impl Type {
             Self::Refinement(refine) => refine.t.typarams_len(),
             // REVIEW:
             Self::Ref(_) | Self::RefMut { .. } => Some(1),
-            Self::And(_, _) | Self::Or(_, _) => Some(2),
+            Self::And(tys) | Self::Or(tys) => Some(tys.len()),
             Self::Not(_) => Some(1),
             Self::Subr(subr) => Some(
                 subr.non_default_params.len()
@@ -3933,9 +3987,7 @@ impl Type {
             Self::FreeVar(_unbound) => vec![],
             Self::Refinement(refine) => refine.t.typarams(),
             Self::Ref(t) | Self::RefMut { before: t, .. } => vec![TyParam::t(*t.clone())],
-            Self::And(lhs, rhs) | Self::Or(lhs, rhs) => {
-                vec![TyParam::t(*lhs.clone()), TyParam::t(*rhs.clone())]
-            }
+            Self::And(tys) | Self::Or(tys) => tys.iter().cloned().map(TyParam::t).collect(),
             Self::Not(t) => vec![TyParam::t(*t.clone())],
             Self::Subr(subr) => subr.typarams(),
             Self::Quantified(quant) => quant.typarams(),
@@ -4156,8 +4208,8 @@ impl Type {
                 let r = r.iter().map(|(k, v)| (k.clone(), v.derefine())).collect();
                 Self::NamedTuple(r)
             }
-            Self::And(l, r) => l.derefine() & r.derefine(),
-            Self::Or(l, r) => l.derefine() | r.derefine(),
+            Self::And(tys) => Self::checked_and(tys.iter().map(|t| t.derefine()).collect()),
+            Self::Or(tys) => Self::checked_or(tys.iter().map(|t| t.derefine()).collect()),
             Self::Not(ty) => !ty.derefine(),
             Self::Proj { lhs, rhs } => lhs.derefine().proj(rhs.clone()),
             Self::ProjCall {
@@ -4224,22 +4276,28 @@ impl Type {
                 });
                 self
             }
-            Self::And(l, r) => {
-                if l.addr_eq(target) {
-                    return r.eliminate_subsup(target);
-                } else if r.addr_eq(target) {
-                    return l.eliminate_subsup(target);
-                }
-                l.eliminate_subsup(target) & r.eliminate_subsup(target)
-            }
-            Self::Or(l, r) => {
-                if l.addr_eq(target) {
-                    return r.eliminate_subsup(target);
-                } else if r.addr_eq(target) {
-                    return l.eliminate_subsup(target);
-                }
-                l.eliminate_subsup(target) | r.eliminate_subsup(target)
-            }
+            Self::And(tys) => Self::checked_and(
+                tys.into_iter()
+                    .filter_map(|t| {
+                        if t.addr_eq(target) {
+                            None
+                        } else {
+                            Some(t.eliminate_subsup(target))
+                        }
+                    })
+                    .collect(),
+            ),
+            Self::Or(tys) => Self::checked_or(
+                tys.into_iter()
+                    .filter_map(|t| {
+                        if t.addr_eq(target) {
+                            None
+                        } else {
+                            Some(t.eliminate_subsup(target))
+                        }
+                    })
+                    .collect(),
+            ),
             other => other,
         }
     }
@@ -4294,8 +4352,16 @@ impl Type {
                 before: Box::new(before.eliminate_recursion(target)),
                 after: after.map(|t| Box::new(t.eliminate_recursion(target))),
             },
-            Self::And(l, r) => l.eliminate_recursion(target) & r.eliminate_recursion(target),
-            Self::Or(l, r) => l.eliminate_recursion(target) | r.eliminate_recursion(target),
+            Self::And(tys) => Self::checked_and(
+                tys.into_iter()
+                    .map(|t| t.eliminate_recursion(target))
+                    .collect(),
+            ),
+            Self::Or(tys) => Self::checked_or(
+                tys.into_iter()
+                    .map(|t| t.eliminate_recursion(target))
+                    .collect(),
+            ),
             Self::Not(ty) => !ty.eliminate_recursion(target),
             Self::Proj { lhs, rhs } => lhs.eliminate_recursion(target).proj(rhs),
             Self::ProjCall {
@@ -4448,8 +4514,8 @@ impl Type {
                 before: Box::new(before.map(f)),
                 after: after.map(|t| Box::new(t.map(f))),
             },
-            Self::And(l, r) => l.map(f) & r.map(f),
-            Self::Or(l, r) => l.map(f) | r.map(f),
+            Self::And(tys) => Self::checked_and(tys.into_iter().map(|t| t.map(f)).collect()),
+            Self::Or(tys) => Self::checked_or(tys.into_iter().map(|t| t.map(f)).collect()),
             Self::Not(ty) => !ty.map(f),
             Self::Proj { lhs, rhs } => lhs.map(f).proj(rhs),
             Self::ProjCall {
@@ -4542,8 +4608,12 @@ impl Type {
                 before: Box::new(before._replace_tp(target, to)),
                 after: after.map(|t| Box::new(t._replace_tp(target, to))),
             },
-            Self::And(l, r) => l._replace_tp(target, to) & r._replace_tp(target, to),
-            Self::Or(l, r) => l._replace_tp(target, to) | r._replace_tp(target, to),
+            Self::And(tys) => {
+                Self::checked_and(tys.into_iter().map(|t| t._replace_tp(target, to)).collect())
+            }
+            Self::Or(tys) => {
+                Self::checked_or(tys.into_iter().map(|t| t._replace_tp(target, to)).collect())
+            }
             Self::Not(ty) => !ty._replace_tp(target, to),
             Self::Proj { lhs, rhs } => lhs._replace_tp(target, to).proj(rhs),
             Self::ProjCall {
@@ -4619,8 +4689,8 @@ impl Type {
                 before: Box::new(before.map_tp(f)),
                 after: after.map(|t| Box::new(t.map_tp(f))),
             },
-            Self::And(l, r) => l.map_tp(f) & r.map_tp(f),
-            Self::Or(l, r) => l.map_tp(f) | r.map_tp(f),
+            Self::And(tys) => Self::checked_and(tys.into_iter().map(|t| t.map_tp(f)).collect()),
+            Self::Or(tys) => Self::checked_or(tys.into_iter().map(|t| t.map_tp(f)).collect()),
             Self::Not(ty) => !ty.map_tp(f),
             Self::Proj { lhs, rhs } => lhs.map_tp(f).proj(rhs),
             Self::ProjCall {
@@ -4708,8 +4778,16 @@ impl Type {
                     after,
                 })
             }
-            Self::And(l, r) => Ok(l.try_map_tp(f)? & r.try_map_tp(f)?),
-            Self::Or(l, r) => Ok(l.try_map_tp(f)? | r.try_map_tp(f)?),
+            Self::And(tys) => Ok(Self::checked_and(
+                tys.into_iter()
+                    .map(|t| t.try_map_tp(f))
+                    .collect::<Result<_, _>>()?,
+            )),
+            Self::Or(tys) => Ok(Self::checked_or(
+                tys.into_iter()
+                    .map(|t| t.try_map_tp(f))
+                    .collect::<Result<_, _>>()?,
+            )),
             Self::Not(ty) => Ok(!ty.try_map_tp(f)?),
             Self::Proj { lhs, rhs } => Ok(lhs.try_map_tp(f)?.proj(rhs)),
             Self::ProjCall {
@@ -4742,9 +4820,25 @@ impl Type {
                 *refine.t = refine.t.replace_param(target, to);
                 Self::Refinement(refine)
             }
-            Self::And(l, r) => l.replace_param(target, to) & r.replace_param(target, to),
+            Self::And(tys) => Self::And(
+                tys.into_iter()
+                    .map(|t| t.replace_param(target, to))
+                    .collect(),
+            ),
             Self::Guard(guard) => Self::Guard(guard.replace_param(target, to)),
             _ => self,
+        }
+    }
+
+    pub fn eliminate_and_or(&mut self) {
+        match self {
+            Self::And(tys) if tys.len() == 1 => {
+                *self = tys.take_all().into_iter().next().unwrap();
+            }
+            Self::Or(tys) if tys.len() == 1 => {
+                *self = tys.take_all().into_iter().next().unwrap();
+            }
+            _ => {}
         }
     }
 
@@ -4815,8 +4909,8 @@ impl Type {
                 }
                 Self::NamedTuple(r)
             }
-            Self::And(l, r) => l.normalize() & r.normalize(),
-            Self::Or(l, r) => l.normalize() | r.normalize(),
+            Self::And(tys) => Self::checked_and(tys.into_iter().map(|t| t.normalize()).collect()),
+            Self::Or(tys) => Self::checked_or(tys.into_iter().map(|t| t.normalize()).collect()),
             Self::Not(ty) => !ty.normalize(),
             Self::Structural(ty) => ty.normalize().structuralize(),
             Self::Quantified(quant) => quant.normalize().quantify(),
@@ -4848,9 +4942,31 @@ impl Type {
             free.get_sub().unwrap_or(self.clone())
         } else {
             match self {
-                Self::And(l, r) => l.lower_bounded() & r.lower_bounded(),
-                Self::Or(l, r) => l.lower_bounded() | r.lower_bounded(),
+                Self::And(tys) => {
+                    Self::checked_and(tys.iter().map(|t| t.lower_bounded()).collect())
+                }
+                Self::Or(tys) => Self::checked_or(tys.iter().map(|t| t.lower_bounded()).collect()),
                 Self::Not(ty) => !ty.lower_bounded(),
+                _ => self.clone(),
+            }
+        }
+    }
+
+    /// ```erg
+    /// assert Int.upper_bounded() == Int
+    /// assert ?T(<: Str).upper_bounded() == Str
+    /// assert (?T(<: Str) or ?U(<: Int)).upper_bounded() == (Str or Int)
+    /// ```
+    pub fn upper_bounded(&self) -> Type {
+        if let Ok(free) = <&FreeTyVar>::try_from(self) {
+            free.get_super().unwrap_or(self.clone())
+        } else {
+            match self {
+                Self::And(tys) => {
+                    Self::checked_and(tys.iter().map(|t| t.upper_bounded()).collect())
+                }
+                Self::Or(tys) => Self::checked_or(tys.iter().map(|t| t.upper_bounded()).collect()),
+                Self::Not(ty) => !ty.upper_bounded(),
                 _ => self.clone(),
             }
         }
@@ -5018,7 +5134,7 @@ impl Type {
         match self {
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().ands(),
             Self::Refinement(refine) => refine.t.ands(),
-            Self::And(l, r) => l.ands().union(&r.ands()),
+            Self::And(tys) => tys.clone(),
             _ => set![self.clone()],
         }
     }
@@ -5031,7 +5147,7 @@ impl Type {
         match self {
             Self::FreeVar(fv) if fv.is_linked() => fv.crack().ors(),
             Self::Refinement(refine) => refine.t.ors(),
-            Self::Or(l, r) => l.ors().union(&r.ors()),
+            Self::Or(tys) => tys.clone(),
             _ => set![self.clone()],
         }
     }
@@ -5076,7 +5192,7 @@ impl Type {
             Self::Callable { param_ts, .. } => {
                 param_ts.iter().flat_map(|t| t.contained_ts()).collect()
             }
-            Self::And(l, r) | Self::Or(l, r) => l.contained_ts().union(&r.contained_ts()),
+            Self::And(tys) | Self::Or(tys) => tys.iter().flat_map(|t| t.contained_ts()).collect(),
             Self::Not(t) => t.contained_ts(),
             Self::Bounded { sub, sup } => sub.contained_ts().union(&sup.contained_ts()),
             Self::Quantified(ty) | Self::Structural(ty) => ty.contained_ts(),
@@ -5145,9 +5261,18 @@ impl Type {
                 }
                 return_t.dereference();
             }
-            Self::And(l, r) | Self::Or(l, r) => {
-                l.dereference();
-                r.dereference();
+            Self::And(tys) | Self::Or(tys) => {
+                *tys = tys
+                    .take_all()
+                    .into_iter()
+                    .map(|mut t| {
+                        t.dereference();
+                        t
+                    })
+                    .collect();
+                if tys.len() == 1 {
+                    *self = tys.take_all().into_iter().next().unwrap();
+                }
             }
             Self::Not(ty) => {
                 ty.dereference();
@@ -5255,7 +5380,7 @@ impl Type {
                 set.extend(return_t.variables());
                 set
             }
-            Self::And(l, r) | Self::Or(l, r) => l.variables().union(&r.variables()),
+            Self::And(tys) | Self::Or(tys) => tys.iter().flat_map(|t| t.variables()).collect(),
             Self::Not(ty) => ty.variables(),
             Self::Bounded { sub, sup } => sub.variables().union(&sup.variables()),
             Self::Quantified(ty) | Self::Structural(ty) => ty.variables(),
@@ -5367,13 +5492,16 @@ impl<'t> ReplaceTable<'t> {
                     self.iterate(l, r);
                 }
             }
-            (Type::And(l, r), Type::And(l2, r2)) => {
-                self.iterate(l, l2);
-                self.iterate(r, r2);
+            // FIXME:
+            (Type::And(tys), Type::And(tys2)) => {
+                for (l, r) in tys.iter().zip(tys2.iter()) {
+                    self.iterate(l, r);
+                }
             }
-            (Type::Or(l, r), Type::Or(l2, r2)) => {
-                self.iterate(l, l2);
-                self.iterate(r, r2);
+            (Type::Or(tys), Type::Or(tys2)) => {
+                for (l, r) in tys.iter().zip(tys2.iter()) {
+                    self.iterate(l, r);
+                }
             }
             (Type::Not(t), Type::Not(t2)) => {
                 self.iterate(t, t2);

--- a/crates/erg_compiler/ty/mod.rs
+++ b/crates/erg_compiler/ty/mod.rs
@@ -1956,6 +1956,7 @@ impl HasType for Type {
 
 impl HasLevel for Type {
     fn level(&self) -> Option<usize> {
+        println!("lev: {self}");
         match self {
             Self::FreeVar(v) => v.level(),
             Self::Ref(t) => t.level(),
@@ -2034,7 +2035,10 @@ impl HasLevel for Type {
                     Some(min)
                 }
             }
-            Self::Structural(ty) => ty.level(),
+            Self::Structural(ty) => {
+                set_recursion_limit!(None, 128);
+                ty.level()
+            }
             Self::Guard(guard) => guard.to.level(),
             Self::Quantified(quant) => quant.level(),
             Self::Bounded { sub, sup } => {

--- a/crates/erg_compiler/ty/value.rs
+++ b/crates/erg_compiler/ty/value.rs
@@ -2080,7 +2080,7 @@ impl ValueObj {
 
     pub fn has_type_satisfies(&self, f: impl Fn(&Type) -> bool + Copy) -> bool {
         match self {
-            Self::Type(t) => t.typ().has_type_satisfies(f),
+            Self::Type(t) => f(t.typ()),
             Self::List(ts) | Self::Tuple(ts) => ts.iter().any(|t| t.has_type_satisfies(f)),
             Self::UnsizedList(elem) => elem.has_type_satisfies(f),
             Self::Set(ts) => ts.iter().any(|t| t.has_type_satisfies(f)),

--- a/tests/should_err/and.er
+++ b/tests/should_err/and.er
@@ -1,0 +1,3 @@
+a as Eq and Hash and Show and Add(Str) = "a"
+f _: Ord and Eq and Show and Hash = None
+f a # ERR

--- a/tests/should_err/or.er
+++ b/tests/should_err/or.er
@@ -1,0 +1,3 @@
+a as Int or Str or NoneType = 1
+f _: Nat or NoneType or Str = None
+f a # ERR

--- a/tests/should_ok/and.er
+++ b/tests/should_ok/and.er
@@ -1,0 +1,7 @@
+a as Eq and Hash and Show = 1
+f _: Eq and Show and Hash = None
+f a
+
+b as Eq and Hash and Ord and Show = 1
+g _: Ord and Eq and Show and Hash = None
+g b

--- a/tests/should_ok/or.er
+++ b/tests/should_ok/or.er
@@ -1,0 +1,7 @@
+a as Nat or Str or NoneType = 1
+f _: Int or NoneType or Str = None
+f a
+
+b as Nat or Str or NoneType or Bool = 1
+g _: Int or NoneType or Bool or Str = None
+g b

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -17,6 +17,11 @@ fn exec_advanced_type_spec() -> Result<(), ()> {
 }
 
 #[test]
+fn exec_and() -> Result<(), ()> {
+    expect_success("tests/should_ok/and.er", 0)
+}
+
+#[test]
 fn exec_args_expansion() -> Result<(), ()> {
     expect_success("tests/should_ok/args_expansion.er", 0)
 }
@@ -328,6 +333,11 @@ fn exec_operators() -> Result<(), ()> {
 }
 
 #[test]
+fn exec_or() -> Result<(), ()> {
+    expect_success("tests/should_ok/or.er", 0)
+}
+
+#[test]
 fn exec_patch() -> Result<(), ()> {
     expect_success("examples/patch.er", 0)
 }
@@ -528,6 +538,11 @@ fn exec_list_member_err() -> Result<(), ()> {
 }
 
 #[test]
+fn exec_and_err() -> Result<(), ()> {
+    expect_failure("tests/should_err/and.er", 0, 1)
+}
+
+#[test]
 fn exec_as() -> Result<(), ()> {
     expect_failure("tests/should_err/as.er", 0, 6)
 }
@@ -632,6 +647,11 @@ fn exec_invalid_param() -> Result<(), ()> {
 #[test]
 fn exec_move_check() -> Result<(), ()> {
     expect_failure("examples/move_check.er", 1, 1)
+}
+
+#[test]
+fn exec_or_err() -> Result<(), ()> {
+    expect_failure("tests/should_err/or.er", 0, 1)
 }
 
 #[test]


### PR DESCRIPTION
In this PR, `Type::{And, Or}`, which previously had a structure of `(Box<Type>, Box<Type>)`, will be flattened to `(Set<Type>)` (however, `And` has a structure of `(Vec<Type>)` due to non-commutativity, which will be described later). 
This ensures the commutativity of `Or` and fixes related bugs. This fix also improves performance, especially for large `And/Or` types. Although `And` types are semantically commutative, it uses `Vec` because it is necessary to fix the order of trials when used as overloaded types.