### PR TITLE
Add glob! and resolve! Methods in Pathlib.d.er

### DIFF
--- a/crates/erg_compiler/context/initialize/classes.rs
+++ b/crates/erg_compiler/context/initialize/classes.rs
@@ -4045,10 +4045,14 @@ impl Context {
             Immutable,
             Visibility::BUILTIN_PRIVATE,
         );
-        let mut g_generator = Self::builtin_mono_class(GENERIC_GENERATOR, 2);
-        g_generator.register_superclass(mono(SUBROUTINE), &subr);
-        let t_yield = fn1_met(mono(GENERIC_GENERATOR), Obj, Never).quantify();
-        g_generator.register_builtin_erg_impl(
+        let generator_t = poly(GENERATOR, vec![ty_tp(T.clone())]);
+        let mut generator = Self::builtin_poly_class(GENERATOR, vec![PS::t_nd(TY_T)], 2);
+        generator.register_superclass(mono(SUBROUTINE), &subr);
+        generator
+            .register_trait(self, poly(ITERATOR, vec![ty_tp(T.clone())]))
+            .unwrap();
+        let t_yield = fn1_met(generator_t.clone(), T.clone(), Never).quantify();
+        generator.register_builtin_erg_impl(
             FUNC_YIELD,
             t_yield,
             Immutable,
@@ -4674,13 +4678,7 @@ impl Context {
         self.register_builtin_type(dict_mut_t, dict_mut, vis.clone(), Const, Some(DICT));
         self.register_builtin_type(set_mut_t, set_mut_, vis.clone(), Const, Some(SET));
         self.register_builtin_type(mono(SUBROUTINE), subr, vis.clone(), Const, Some(SUBROUTINE));
-        self.register_builtin_type(
-            mono(GENERIC_GENERATOR),
-            g_generator,
-            vis.clone(),
-            Const,
-            Some(GENERATOR),
-        );
+        self.register_builtin_type(generator_t, generator, vis.clone(), Const, Some(GENERATOR));
         self.register_builtin_type(dimension_t, dimension, vis.clone(), Const, Some(DIMENSION));
         self.register_builtin_type(
             mono(BASE_EXCEPTION),

--- a/crates/erg_compiler/context/initialize/mod.rs
+++ b/crates/erg_compiler/context/initialize/mod.rs
@@ -352,7 +352,6 @@ const PROC_INVERT: &str = "invert!";
 const RANGE: &str = "Range";
 const GENERIC_CALLABLE: &str = "GenericCallable";
 const SUBROUTINE: &str = "Subroutine";
-const GENERIC_GENERATOR: &str = "GenericGenerator";
 const FUNC_RETURN: &str = "return";
 const FUNC_YIELD: &str = "yield";
 const PROC: &str = "Proc";

--- a/crates/erg_compiler/lib/pystd/pathlib.d.er
+++ b/crates/erg_compiler/lib/pystd/pathlib.d.er
@@ -45,7 +45,7 @@
     chmod!: (self: .Path, mode: Nat) => NoneType
     exists!: (self: .Path) => Bool
     expanduser!: (self: .Path) => .Path
-    glob!: (self: .Path, pattern: Str) -> Generator .Path
+    glob!: (self: .Path, pattern: Str) => Generator .Path
     home!: () => .Path
     iterdir!: (self: .Path) => Generator .Path
     joinpath: (self: .Path, *other: PathLike) -> .Path

--- a/crates/erg_compiler/lib/pystd/pathlib.d.er
+++ b/crates/erg_compiler/lib/pystd/pathlib.d.er
@@ -45,9 +45,9 @@
     chmod!: (self: .Path, mode: Nat) => NoneType
     exists!: (self: .Path) => Bool
     expanduser!: (self: .Path) => .Path
-    glob!: (self: .Path, pattern: Str) -> Iterable .Path
+    glob!: (self: .Path, pattern: Str) -> Generator .Path
     home!: () => .Path
-    iterdir!: (self: .Path) => Iterable .Path
+    iterdir!: (self: .Path) => Generator .Path
     joinpath: (self: .Path, *other: PathLike) -> .Path
     mkdir!: (self: .Path, mode := Nat, parents := Bool, exist_ok := Bool) => NoneType
     open!: (self: .Path, mode := Str) => File!

--- a/crates/erg_compiler/lib/pystd/pathlib.d.er
+++ b/crates/erg_compiler/lib/pystd/pathlib.d.er
@@ -45,6 +45,7 @@
     chmod!: (self: .Path, mode: Nat) => NoneType
     exists!: (self: .Path) => Bool
     expanduser!: (self: .Path) => .Path
+    glob!: (self: .Path, pattern: Str) -> Iterable .Path
     home!: () => .Path
     iterdir!: (self: .Path) => Iterable .Path
     joinpath: (self: .Path, *other: PathLike) -> .Path
@@ -54,6 +55,7 @@
     read_bytes!: (self: .Path) => Bytes
     read_text!: (self: .Path, encoding := Str, errors := Str) => Str
     rename!: (self: .Path, target: PathLike) => NoneType
+    resolve!: (self: .Path, strict := Bool) => .Path
     samefile!: (self: .Path, other: PathLike) => Bool
     touch!: (self: .Path, mode := Nat, exist_ok := Bool) => NoneType
     unlink!: (self: .Path, missing_ok := Bool) => NoneType


### PR DESCRIPTION
```py
{Path;} = pyimport "pathlib"
crr = Path()

print! crr # WindowsPath('.')

print! crr.resolve!() # WindowsPath('C:/Users/user/Desktop/erg')

for! crr.glob!("**/*.er"), pth =>
     print! pth
     
bump_version.er
crates\els\tests\a.er
...
tests\should_ok\many_import\unused_import.er
```

Changes proposed in this PR:
- resolve!()
- glob!()

@mtshiba
