### PR TITLE
Fix `py_compat` build feature name.md

### DIFF
--- a/doc/EN/dev_guide/build_features.md
+++ b/doc/EN/dev_guide/build_features.md
@@ -37,7 +37,7 @@ Increase the thread stack size. Used for Windows execution and test execution.
 `--language-server` option becomes available.
 `erg --language-server` will start the Erg language server.
 
-## py_compatible
+## py_compat
 
 Enable Python-compatible mode, which makes parts of the APIs and syntax compatible with Python. Used for [pylyzer](https://github.com/mtshiba/pylyzer).
 


### PR DESCRIPTION
The `py_compat` feature flag was incorrectly referred to as `py_compatible`:

https://github.com/erg-lang/erg/blob/8043a13644e86e4d3b6676869b55081665b2dc4e/Cargo.toml#L68

And now it isn't anymore 😄 

@mtshiba
