### PR TITLE
Update Cargo Edition 2021 to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 version = "0.6.53"
 authors = ["erg-lang team <moderation.erglang@gmail.com>"]
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/erg-lang/erg"
 homepage = "https://erg-lang.org/"
 

--- a/crates/els/call_hierarchy.rs
+++ b/crates/els/call_hierarchy.rs
@@ -54,8 +54,8 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
                 let Some(pos) = loc_to_pos(referrer_loc.loc) else {
                     continue;
                 };
-                if let Some(def) = self.get_min::<Def>(&uri, pos) {
-                    if def.sig.is_subr() {
+                if let Some(def) = self.get_min::<Def>(&uri, pos)
+                    && def.sig.is_subr() {
                         let Some(from) =
                             hierarchy_item(def.sig.inspect().to_string(), &def.sig.ident().vi)
                         else {
@@ -67,7 +67,6 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
                         };
                         res.push(call);
                     }
-                }
             }
         }
         Ok(Some(res))
@@ -196,14 +195,13 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
         let mut res = vec![];
         let uri = NormalizedUrl::new(params.text_document_position_params.text_document.uri);
         let pos = params.text_document_position_params.position;
-        if let Some(token) = self.file_cache.get_symbol(&uri, pos) {
-            if let Some(vi) = self.get_definition(&uri, &token)? {
+        if let Some(token) = self.file_cache.get_symbol(&uri, pos)
+            && let Some(vi) = self.get_definition(&uri, &token)? {
                 let Some(item) = hierarchy_item(token.content.to_string(), &vi) else {
                     return Ok(None);
                 };
                 res.push(item);
             }
-        }
         Ok(Some(res))
     }
 }

--- a/crates/els/code_action.rs
+++ b/crates/els/code_action.rs
@@ -194,12 +194,11 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
     fn send_normal_action(&self, params: &CodeActionParams) -> ELSResult<Vec<CodeAction>> {
         let mut actions = vec![];
         let uri = NormalizedUrl::new(params.text_document.uri.clone());
-        if let Some(token) = self.file_cache.get_token(&uri, params.range.start) {
-            if token.is(TokenKind::Symbol) && !token.is_const() && !token.content.is_snake_case() {
+        if let Some(token) = self.file_cache.get_token(&uri, params.range.start)
+            && token.is(TokenKind::Symbol) && !token.is_const() && !token.content.is_snake_case() {
                 let action = self.gen_change_case_action(token, &uri, params.clone());
                 actions.extend(action);
             }
-        }
         actions.extend(self.send_quick_fix(params)?);
         actions.extend(self.gen_extract_action(params));
         actions.extend(self.gen_inline_action(params));

--- a/crates/els/completion.rs
+++ b/crates/els/completion.rs
@@ -662,8 +662,8 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
                 }
                 _ => None,
             });
-        if PYTHON_MODE {
-            if let Some(receiver_t) = &receiver_t {
+        if PYTHON_MODE
+            && let Some(receiver_t) = &receiver_t {
                 for (field, ty) in mod_ctx.context.fields(receiver_t) {
                     let mut item =
                         CompletionItem::new_simple(field.symbol.to_string(), ty.to_string());
@@ -681,7 +681,6 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
                     result.push(item);
                 }
             }
-        }
         if let Some(receiver_t) = &receiver_t {
             result.extend(self.magic_completion_items(
                 &comp_kind,

--- a/crates/els/definition.rs
+++ b/crates/els/definition.rs
@@ -43,8 +43,7 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
                 // `{x;} = import "foo"` => jump to `x` of `foo.er`
                 if vi.def_loc.module == Some(util::uri_to_path(uri).into())
                     && vi.def_loc.loc == token.loc()
-                {
-                    if let Some(def) = self.get_min::<Def>(uri, pos) {
+                    && let Some(def) = self.get_min::<Def>(uri, pos) {
                         if def.def_kind().is_import() {
                             if let Some(mod_uri) =
                                 vi.t.module_path()
@@ -101,7 +100,6 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
                             }
                         }
                     }
-                }
                 match (vi.def_loc.module, util::loc_to_range(vi.def_loc.loc)) {
                     (Some(path), Some(range)) => {
                         let def_uri = Url::from_file_path(path).unwrap();

--- a/crates/els/diagnostics.rs
+++ b/crates/els/diagnostics.rs
@@ -419,14 +419,13 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
                             file_vers.insert(uri.clone(), latest_ver);
                             continue;
                         };
-                        if latest_ver != ver {
-                            if let Ok(code) = _self.file_cache.get_entire_code(&uri) {
+                        if latest_ver != ver
+                            && let Ok(code) = _self.file_cache.get_entire_code(&uri) {
                                 let mut checked = Set::new();
                                 let _ = _self.check_file(uri.clone(), code, &mut checked);
                                 _self.send_empty_diagnostics(checked).unwrap();
                                 file_vers.insert(uri, latest_ver);
                             }
-                        }
                     }
                     sleep(Duration::from_millis(500));
                 }

--- a/crates/els/diff.rs
+++ b/crates/els/diff.rs
@@ -127,11 +127,9 @@ impl HIRDiff {
                 if let ast::Expr::Def(def)
                 | ast::Expr::ClassDef(ast::ClassDef { def, .. })
                 | ast::Expr::PatchDef(ast::PatchDef { def, .. }) = &expr
-                {
-                    if let Some(name) = def.sig.name_as_str() {
+                    && let Some(name) = def.sig.name_as_str() {
                         lowerer.unregister(name);
                     }
-                }
                 let expr = match lowerer.lower_and_resolve_chunk(expr, None) {
                     Ok(expr) => expr,
                     Err((opt_expr, _err)) => opt_expr?,

--- a/crates/els/doc_highlight.rs
+++ b/crates/els/doc_highlight.rs
@@ -26,8 +26,8 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
         let Some(visitor) = self.get_visitor(uri) else {
             return res;
         };
-        if let Some(tok) = self.file_cache.get_symbol(uri, pos) {
-            if let Some(vi) = visitor.get_info(&tok) {
+        if let Some(tok) = self.file_cache.get_symbol(uri, pos)
+            && let Some(vi) = visitor.get_info(&tok) {
                 if let Some(range) = loc_to_range(vi.def_loc.loc) {
                     res.push(DocumentHighlight {
                         range,
@@ -41,7 +41,6 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
                     });
                 }
             }
-        }
         res
     }
 }

--- a/crates/els/doc_link.rs
+++ b/crates/els/doc_link.rs
@@ -177,11 +177,10 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
                         tooltip: Some(format!("module {word}")),
                         data: None,
                     });
-                } else if let Some((_, vi)) = mod_ctx.context.get_type_info(&typ) {
-                    if let Some(doc) = self.gen_doc_link_from_vi(word, range, vi) {
+                } else if let Some((_, vi)) = mod_ctx.context.get_type_info(&typ)
+                    && let Some(doc) = self.gen_doc_link_from_vi(word, range, vi) {
                         res.push(doc);
                     }
-                }
                 col += word.len() as u32 + 1;
             }
             line += 1;

--- a/crates/els/file_cache.rs
+++ b/crates/els/file_cache.rs
@@ -274,12 +274,11 @@ impl FileCache {
     pub(crate) fn update(&self, uri: &NormalizedUrl, code: String, ver: Option<i32>) {
         let lock = self.files.borrow_mut();
         let entry = lock.get(uri);
-        if let Some(entry) = entry {
-            if ver.is_some_and(|ver| ver <= entry.ver) {
+        if let Some(entry) = entry
+            && ver.is_some_and(|ver| ver <= entry.ver) {
                 // crate::_log!(self, "171: double update detected: {ver:?}, {}, code:\n{}", entry.ver, entry.code);
                 return;
             }
-        }
         let token_stream = match Lexer::from_str(code.clone()).lex() {
             Ok(ts) => Some(ts),
             Err((ts, es)) => {

--- a/crates/els/hir_visitor.rs
+++ b/crates/els/hir_visitor.rs
@@ -350,11 +350,10 @@ impl<'a> HIRVisitor<'a> {
                 return Some(expr);
             }
         }
-        if let Some(var) = &args.var_args {
-            if let Some(expr) = self.get_expr(&var.expr, pos) {
+        if let Some(var) = &args.var_args
+            && let Some(expr) = self.get_expr(&var.expr, pos) {
                 return Some(expr);
             }
-        }
         for arg in args.kw_args.iter() {
             if let Some(expr) = self.get_expr(&arg.expr, pos) {
                 return Some(expr);
@@ -628,11 +627,10 @@ impl HIRVisitor<'_> {
     }
 
     fn get_call_info(&self, call: &Call, token: &Token) -> Option<VarInfo> {
-        if let Some(attr) = &call.attr_name {
-            if let Some(t) = self.return_var_info_if_same(attr, attr.raw.name.token(), token) {
+        if let Some(attr) = &call.attr_name
+            && let Some(t) = self.return_var_info_if_same(attr, attr.raw.name.token(), token) {
                 return Some(t);
             }
-        }
         self.get_expr_info(&call.obj, token)
             .or_else(|| self.get_args_info(&call.args, token))
     }
@@ -643,11 +641,10 @@ impl HIRVisitor<'_> {
                 return Some(vi);
             }
         }
-        if let Some(var) = &args.var_args {
-            if let Some(vi) = self.get_expr_info(&var.expr, token) {
+        if let Some(var) = &args.var_args
+            && let Some(vi) = self.get_expr_info(&var.expr, token) {
                 return Some(vi);
             }
-        }
         for arg in args.kw_args.iter() {
             if let Some(vi) = self.get_expr_info(&arg.expr, token) {
                 return Some(vi);
@@ -715,11 +712,10 @@ impl HIRVisitor<'_> {
             }
         }
         for guard in params.guards.iter() {
-            if let GuardClause::Bind(bind) = guard {
-                if let Some(vi) = self.get_def_info(bind, token) {
+            if let GuardClause::Bind(bind) = guard
+                && let Some(vi) = self.get_def_info(bind, token) {
                     return Some(vi);
                 }
-            }
         }
         None
     }
@@ -869,21 +865,19 @@ impl HIRVisitor<'_> {
                         return Some(parent);
                     }
                 }
-                if let Some(var) = &call.args.var_args {
-                    if let Some(parent) = self.get_parent_expr(&var.expr, expr_loc) {
+                if let Some(var) = &call.args.var_args
+                    && let Some(parent) = self.get_parent_expr(&var.expr, expr_loc) {
                         return Some(parent);
                     }
-                }
                 for arg in call.args.kw_args.iter() {
                     if let Some(parent) = self.get_parent_expr(&arg.expr, expr_loc) {
                         return Some(parent);
                     }
                 }
-                if let Some(kw_var) = &call.args.kw_var {
-                    if let Some(parent) = self.get_parent_expr(&kw_var.expr, expr_loc) {
+                if let Some(kw_var) = &call.args.kw_var
+                    && let Some(parent) = self.get_parent_expr(&kw_var.expr, expr_loc) {
                         return Some(parent);
                     }
-                }
                 None
             }
             Expr::Def(def) => {

--- a/crates/els/hover.rs
+++ b/crates/els/hover.rs
@@ -168,15 +168,14 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
                 }
                 // not found or not symbol, etc.
                 None => {
-                    if let Some(visitor) = self.get_visitor(&uri) {
-                        if let Some(typ) = visitor.get_min_expr(pos) {
+                    if let Some(visitor) = self.get_visitor(&uri)
+                        && let Some(typ) = visitor.get_min_expr(pos) {
                             let typ = MarkedString::from_language_code(
                                 ERG_LANG.into(),
                                 format!("{}: {typ}", token.content),
                             );
                             contents.push(typ);
                         }
-                    }
                 }
             }
             if let Some(visitor) = self.get_visitor(&uri) {
@@ -243,8 +242,8 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
                 }) else {
                     continue;
                 };
-                if let Some((_, vi)) = module.context.get_type_info(&inner_t) {
-                    if let Some(url) = vi
+                if let Some((_, vi)) = module.context.get_type_info(&inner_t)
+                    && let Some(url) = vi
                         .def_loc
                         .module
                         .as_ref()
@@ -256,7 +255,6 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
                             vi.def_loc.loc.ln_begin().unwrap_or(1)
                         );
                     }
-                }
             }
         }
         if !defs.is_empty() {

--- a/crates/els/inlay_hint.rs
+++ b/crates/els/inlay_hint.rs
@@ -303,13 +303,13 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
         self.send_log(format!("inlay hint request: {params:?}"))?;
         let uri = NormalizedUrl::new(params.text_document.uri);
         let mut result = vec![];
-        let gen = InlayHintGenerator {
+        let hint_gen = InlayHintGenerator {
             _server: self,
             uri: uri.clone().raw().to_string().into(),
         };
         if let Some(hir) = self.get_hir(&uri) {
             for chunk in hir.module.iter() {
-                result.extend(gen.get_expr_hint(chunk));
+                result.extend(hint_gen.get_expr_hint(chunk));
             }
         }
         Ok(Some(result))

--- a/crates/els/inlay_hint.rs
+++ b/crates/els/inlay_hint.rs
@@ -187,12 +187,11 @@ impl<C: BuildRunnable, P: Parsable> InlayHintGenerator<'_, C, P> {
                 let hint = self.type_anot(ln, col, return_t, subr.params.parens.is_none());
                 result.push(hint);
             }
-            if subr.params.parens.is_none() {
-                if let Some((ln, col)) = subr.params.ln_begin().zip(subr.params.col_begin()) {
+            if subr.params.parens.is_none()
+                && let Some((ln, col)) = subr.params.ln_begin().zip(subr.params.col_begin()) {
                     let hint = self.anot(ln, col, "(".to_string());
                     result.push(hint);
                 }
-            }
         }
         result
     }
@@ -200,12 +199,11 @@ impl<C: BuildRunnable, P: Parsable> InlayHintGenerator<'_, C, P> {
     fn get_var_def_hint(&self, def: &Def) -> Vec<InlayHint> {
         let mut result = self.get_block_hint(&def.body.block);
         // don't show hints for compiler internal variables
-        if def.sig.t_spec().is_none() && !def.sig.ident().inspect().starts_with(['%']) {
-            if let Some((ln, col)) = def.sig.ln_begin().zip(def.sig.col_end()) {
+        if def.sig.t_spec().is_none() && !def.sig.ident().inspect().starts_with(['%'])
+            && let Some((ln, col)) = def.sig.ln_begin().zip(def.sig.col_end()) {
                 let hint = self.type_anot(ln, col, def.sig.ident().ref_t(), false);
                 result.push(hint);
             }
-        }
         result
     }
 
@@ -213,12 +211,11 @@ impl<C: BuildRunnable, P: Parsable> InlayHintGenerator<'_, C, P> {
         let mut result = vec![];
         result.extend(self.get_block_hint(&lambda.body));
         result.extend(self.get_param_hint(&lambda.params));
-        if lambda.params.parens.is_none() {
-            if let Some((ln, col)) = lambda.params.ln_begin().zip(lambda.params.col_begin()) {
+        if lambda.params.parens.is_none()
+            && let Some((ln, col)) = lambda.params.ln_begin().zip(lambda.params.col_begin()) {
                 let hint = self.anot(ln, col, "(".to_string());
                 result.push(hint);
             }
-        }
         if let Some(((ln, col), return_t)) = lambda
             .params
             .ln_end()

--- a/crates/els/references.rs
+++ b/crates/els/references.rs
@@ -21,13 +21,11 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
     }
 
     fn show_refs_inner(&self, uri: &NormalizedUrl, pos: Position) -> Vec<lsp_types::Location> {
-        if let Some(tok) = self.file_cache.get_symbol(uri, pos) {
-            if let Some(visitor) = self.get_visitor(uri) {
-                if let Some(vi) = visitor.get_info(&tok) {
+        if let Some(tok) = self.file_cache.get_symbol(uri, pos)
+            && let Some(visitor) = self.get_visitor(uri)
+                && let Some(vi) = visitor.get_info(&tok) {
                     return self.get_refs_from_abs_loc(&vi.def_loc);
                 }
-            }
-        }
         vec![]
     }
 

--- a/crates/els/server.rs
+++ b/crates/els/server.rs
@@ -282,11 +282,10 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
                 if let Some(&feature) = args.next() {
                     disabled_features.push(DefaultFeatures::from(feature));
                 }
-            } else if arg == "--enable" {
-                if let Some(&feature) = args.next() {
+            } else if arg == "--enable"
+                && let Some(&feature) = args.next() {
                     opt_features.push(OptionalFeatures::from(feature));
                 }
-            }
         }
         let external_items = !disabled_features.contains(&DefaultFeatures::DeepCompletion);
         Self {

--- a/crates/els/sig_help.rs
+++ b/crates/els/sig_help.rs
@@ -85,11 +85,10 @@ impl<Checker: BuildRunnable, Parser: Parsable> Server<Checker, Parser> {
     ) -> Option<(Token, Expr)> {
         let token = self.file_cache.get_token_relatively(uri, pos, offset)?;
         crate::_log!(self, "token: {token}");
-        if let Some(visitor) = self.get_visitor(uri) {
-            if let Some(expr) = visitor.get_min_expr(loc_to_pos(token.loc())?) {
+        if let Some(visitor) = self.get_visitor(uri)
+            && let Some(expr) = visitor.get_min_expr(loc_to_pos(token.loc())?) {
                 return Some((token, expr.clone()));
             }
-        }
         None
     }
 

--- a/crates/erg_common/error.rs
+++ b/crates/erg_common/error.rs
@@ -376,8 +376,8 @@ impl Ord for Location {
     }
 }
 
+#[allow(clippy::non_canonical_partial_ord_impl)]
 impl PartialOrd for Location {
-    #[allow(clippy::non_canonical_partial_ord_impl)]
     fn partial_cmp(&self, other: &Location) -> Option<Ordering> {
         if self.is_unknown() || other.is_unknown() {
             None

--- a/crates/erg_common/io.rs
+++ b/crates/erg_common/io.rs
@@ -650,13 +650,13 @@ impl Input {
         // -> lib/external/pandas.d
         // root: lib/external/pandas.d, path: contextlib
         // -> NO
-        if let Some((root, first)) = self.project_root().zip(path.components().next()) {
-            if root.ends_with(first) || remove_postfix(root.clone(), ".d").ends_with(first) {
-                let path_buf = path.iter().skip(1).collect::<PathBuf>();
-                if let Ok(resolved) = self.resolve_local_decl(root.clone(), &path_buf) {
-                    VFS.cache_path(self.clone(), path.to_path_buf(), Some(resolved.clone()));
-                    return Some(resolved);
-                }
+        if let Some((root, first)) = self.project_root().zip(path.components().next())
+            && (root.ends_with(first) || remove_postfix(root.clone(), ".d").ends_with(first))
+        {
+            let path_buf = path.iter().skip(1).collect::<PathBuf>();
+            if let Ok(resolved) = self.resolve_local_decl(root.clone(), &path_buf) {
+                VFS.cache_path(self.clone(), path.to_path_buf(), Some(resolved.clone()));
+                return Some(resolved);
             }
         }
         if let Some(resolved) = Self::resolve_std_decl_path(erg_pystd_path(), path) {
@@ -674,13 +674,13 @@ impl Input {
                 return Some(resolved);
             }
         }
-        if PYTHON_MODE {
-            if let Ok(resolved) = self.resolve_py(path) {
-                if cfg.respect_pyi && resolved.with_extension("pyi").exists() {
-                    return Some(resolved.with_extension("pyi"));
-                }
-                return Some(resolved);
+        if PYTHON_MODE
+            && let Ok(resolved) = self.resolve_py(path)
+        {
+            if cfg.respect_pyi && resolved.with_extension("pyi").exists() {
+                return Some(resolved.with_extension("pyi"));
             }
+            return Some(resolved);
         }
         VFS.cache_path(self.clone(), path.to_path_buf(), None);
         None

--- a/crates/erg_common/macros.rs
+++ b/crates/erg_common/macros.rs
@@ -298,9 +298,7 @@ macro_rules! switch_unreachable {
 
 #[macro_export]
 macro_rules! assume_unreachable {
-    () => {{
-        unsafe { std::hint::unreachable_unchecked() }
-    }};
+    () => {{ unsafe { std::hint::unreachable_unchecked() } }};
 }
 
 /// indicates the current invoked function.
@@ -337,7 +335,7 @@ macro_rules! fn_name {
 macro_rules! caused_by {
     () => {{
         let fn_name = $crate::fn_name!();
-        &format!("{fn_name} at line {}", line!())
+        format!("{fn_name} at line {}", line!())
     }};
 }
 
@@ -355,16 +353,12 @@ macro_rules! addr {
 /// do not use for reference types
 #[macro_export]
 macro_rules! addr_eq {
-    ($l: expr, $r: expr $(,)*) => {{
-        &$l as *const _ == &$r as *const _
-    }};
+    ($l: expr, $r: expr $(,)*) => {{ &$l as *const _ == &$r as *const _ }};
 }
 
 #[macro_export]
 macro_rules! ref_addr_eq {
-    ($l: expr, $r: expr $(,)*) => {{
-        $l as *const _ == $r as *const _
-    }};
+    ($l: expr, $r: expr $(,)*) => {{ $l as *const _ == $r as *const _ }};
 }
 
 #[macro_export]
@@ -436,7 +430,7 @@ macro_rules! debug_enum_assert {
 macro_rules! debug_info {
     ($output:ident) => {{
         #[allow(unused_imports)]
-        use $crate::style::{colors::DEBUG, RESET};
+        use $crate::style::{RESET, colors::DEBUG};
         write!(
             $output,
             "[{}DEBUG{}] {}:{:04}: ",
@@ -449,7 +443,7 @@ macro_rules! debug_info {
     }};
     () => {{
         #[allow(unused_imports)]
-        use $crate::style::{colors::DEBUG, RESET};
+        use $crate::style::{RESET, colors::DEBUG};
         print!("[{}DEBUG{}] {}:{:04}: ", DEBUG, RESET, file!(), line!());
     }};
 }

--- a/crates/erg_common/shared.rs
+++ b/crates/erg_common/shared.rs
@@ -269,7 +269,7 @@ impl<T: ?Sized> Shared<T> {
     /// # Safety
     /// don't call this except you need to handle cyclic references.
     pub unsafe fn force_unlock_write(&self) {
-        self.data.force_unlock_write();
+        unsafe { self.data.force_unlock_write() };
     }
 }
 

--- a/crates/erg_common/style.rs
+++ b/crates/erg_common/style.rs
@@ -641,10 +641,10 @@ impl StyledStrings {
     }
 
     fn attr_is(&self, attr: Attribute) -> bool {
-        if let Some(text) = self.texts.last() {
-            if let Some(text_attr) = text.attribute {
-                return text_attr == attr;
-            }
+        if let Some(text) = self.texts.last()
+            && let Some(text_attr) = text.attribute
+        {
+            return text_attr == attr;
         }
         false
     }

--- a/crates/erg_common/traits.rs
+++ b/crates/erg_common/traits.rs
@@ -869,15 +869,15 @@ pub trait Runnable: Sized + Default + New {
                     match bk {
                         BlockKind::None if vm.now == BlockKind::AtMark => {
                             if let Some(eq) = line.find('=') {
-                                if let Some(class) = line.find("Class") {
-                                    if eq < class {
-                                        vm.push_code(indent.as_str());
-                                        instance.input().insert_whitespace(indent.as_str());
-                                        vm.push_code(line);
-                                        vm.push_code("\n");
-                                        vm.push_block_kind(bk);
-                                        continue;
-                                    }
+                                if let Some(class) = line.find("Class")
+                                    && eq < class
+                                {
+                                    vm.push_code(indent.as_str());
+                                    instance.input().insert_whitespace(indent.as_str());
+                                    vm.push_code(line);
+                                    vm.push_code("\n");
+                                    vm.push_block_kind(bk);
+                                    continue;
                                 }
                                 vm.push_code(indent.as_str());
                                 instance.input().insert_whitespace(indent.as_str());

--- a/crates/erg_compiler/build_package.rs
+++ b/crates/erg_compiler/build_package.rs
@@ -453,26 +453,23 @@ impl<ASTBuilder: ASTBuildable, HIRBuilder: Buildable>
                         errs.extend(err);
                     }
                 }
-                if let Some(var) = call.args.var_args.as_mut() {
-                    if let Err(err) = self.check_import(&mut var.expr, cfg) {
+                if let Some(var) = call.args.var_args.as_mut()
+                    && let Err(err) = self.check_import(&mut var.expr, cfg) {
                         errs.extend(err);
                     }
-                }
                 for kw in call.args.kw_args.iter_mut() {
                     if let Err(err) = self.check_import(&mut kw.expr, cfg) {
                         errs.extend(err);
                     }
                 }
-                if let Some(kw_var) = call.args.kw_var_args.as_mut() {
-                    if let Err(err) = self.check_import(&mut kw_var.expr, cfg) {
+                if let Some(kw_var) = call.args.kw_var_args.as_mut()
+                    && let Err(err) = self.check_import(&mut kw_var.expr, cfg) {
                         errs.extend(err);
                     }
-                }
-                if call.additional_operation().is_some_and(|op| op.is_import()) {
-                    if let Err(err) = self.register(expr, cfg) {
+                if call.additional_operation().is_some_and(|op| op.is_import())
+                    && let Err(err) = self.register(expr, cfg) {
                         errs.extend(err);
                     }
-                }
             }
             Expr::Def(def) => {
                 for expr in def.body.block.iter_mut() {
@@ -636,8 +633,7 @@ impl<ASTBuilder: ASTBuildable, HIRBuilder: Buildable>
                     .stderr(err)
                     .spawn()
                     .and_then(|mut child| child.wait())
-                {
-                    if let Some(path) = self
+                    && let Some(path) = self
                         .cfg
                         .input
                         .resolve_decl_path(Path::new(&__name__[..]), &self.cfg)
@@ -652,7 +648,6 @@ impl<ASTBuilder: ASTBuildable, HIRBuilder: Buildable>
                             return Ok(path);
                         }
                     }
-                }
             }
         }
         Err(())
@@ -726,8 +721,8 @@ impl<ASTBuilder: ASTBuildable, HIRBuilder: Buildable>
             None
         };
         let root_import_path = root_path.and_then(|path| cfg.input.resolve_path(path, cfg));
-        if let Some(root_import_path) = root_import_path.map(NormalizedPathBuf::from) {
-            if project_entry_dir_of(&root_import_path) != project_entry_dir_of(&from_path) {
+        if let Some(root_import_path) = root_import_path.map(NormalizedPathBuf::from)
+            && project_entry_dir_of(&root_import_path) != project_entry_dir_of(&from_path) {
                 let root_import_cfg = cfg.inherit(root_import_path.to_path_buf());
                 self.shared.graph.add_node_if_none(&root_import_path);
                 let _ = self
@@ -746,7 +741,6 @@ impl<ASTBuilder: ASTBuildable, HIRBuilder: Buildable>
                     debug_assert!(prev.is_none());
                 }
             }
-        }
         // root -> a -> b -> a
         // b: submodule
         if let Err(_err) = self.shared.graph.inc_ref(&from_path, import_path.clone()) {

--- a/crates/erg_compiler/codegen.rs
+++ b/crates/erg_compiler/codegen.rs
@@ -3265,8 +3265,8 @@ impl PyCodeGenerator {
 
     /// Emits independent code blocks (e.g., linked other modules)
     fn emit_code(&mut self, code: Block) {
-        let mut gen = self.inherit();
-        let code = gen.emit_block(code, vec![], None, vec![], 0, vec![], 0);
+        let mut codegen = self.inherit();
+        let code = codegen.emit_block(code, vec![], None, vec![], 0, vec![], 0);
         self.emit_load_const(code);
     }
 

--- a/crates/erg_compiler/codegen.rs
+++ b/crates/erg_compiler/codegen.rs
@@ -649,8 +649,8 @@ impl PyCodeGenerator {
     }
 
     fn local_search(&self, name: &str, acc_kind: AccessKind) -> Option<Name> {
-        if self.py_version.minor < Some(11) {
-            if let Some(idx) = self
+        if self.py_version.minor < Some(11)
+            && let Some(idx) = self
                 .cur_block_codeobj()
                 .cellvars
                 .iter()
@@ -658,7 +658,6 @@ impl PyCodeGenerator {
             {
                 return Some(Name::deref(idx));
             }
-        }
         match acc_kind {
             AccessKind::Name => {
                 if let Some(idx) = self

--- a/crates/erg_compiler/context/compare.rs
+++ b/crates/erg_compiler/context/compare.rs
@@ -265,13 +265,12 @@ impl Context {
 
     fn _find_compatible_glue_patch(&self, sup: &Type, sub: &Type) -> Option<&Context> {
         for patch in self.all_patches().into_iter() {
-            if let ContextKind::GluePatch(tr_impl) = &patch.kind {
-                if self.subtype_of(sub, &tr_impl.sub_type)
+            if let ContextKind::GluePatch(tr_impl) = &patch.kind
+                && self.subtype_of(sub, &tr_impl.sub_type)
                     && self.subtype_of(&tr_impl.sup_trait, sup)
                 {
                     return Some(patch);
                 }
-            }
         }
         None
     }
@@ -541,11 +540,10 @@ impl Context {
                     args.clone(),
                     self.level,
                     &(),
-                ) {
-                    if lhs != &evaled {
+                )
+                    && lhs != &evaled {
                         return self.supertype_of(&evaled, rhs);
                     }
-                }
                 // REVIEW: is this OK?
                 if lhs.has_unbound_var() {
                     return true;
@@ -566,11 +564,10 @@ impl Context {
                     args.clone(),
                     self.level,
                     &(),
-                ) {
-                    if &evaled != rhs {
+                )
+                    && &evaled != rhs {
                         return self.supertype_of(lhs, &evaled);
                     }
-                }
                 if rhs.has_unbound_var() {
                     return true;
                 }
@@ -816,11 +813,10 @@ impl Context {
             (Refinement(l), r) => {
                 if let Some(r) = r.to_singleton() {
                     return self.structural_supertype_of(lhs, &Type::Refinement(r));
-                } else if let Some(l) = self.refinement_to_poly(l) {
-                    if &l != lhs {
+                } else if let Some(l) = self.refinement_to_poly(l)
+                    && &l != lhs {
                         return self.supertype_of(&l, r);
                     }
-                }
                 if l.pred.mentions(&l.var) {
                     match l.pred.can_be_false() {
                         Some(true) => {
@@ -1189,11 +1185,9 @@ impl Context {
                 }
                 if let Some((sup_var, sub_var)) =
                     sup_l.var_params.as_ref().zip(sub_l.var_params.as_ref())
-                {
-                    if !self.subtype_of(sup_var.typ(), sub_var.typ()) {
+                    && !self.subtype_of(sup_var.typ(), sub_var.typ()) {
                         return false;
                     }
-                }
                 for (sup_d, sub_d) in sup_l.d_params.iter().zip(sub_l.d_params.iter()) {
                     if !self.subtype_of(sup_d.typ(), sub_d.typ()) {
                         return false;
@@ -1203,11 +1197,9 @@ impl Context {
                     .kw_var_params
                     .as_ref()
                     .zip(sub_l.kw_var_params.as_ref())
-                {
-                    if !self.subtype_of(sup_kw_var.typ(), sub_kw_var.typ()) {
+                    && !self.subtype_of(sup_kw_var.typ(), sub_kw_var.typ()) {
                         return false;
                     }
-                }
                 true
             }
             (TyParam::FreeVar(fv), _) if fv.is_unbound() => {
@@ -1270,21 +1262,17 @@ impl Context {
             (TyParam::ProjCall { obj, attr, args }, _) => {
                 if let Ok(evaled) =
                     self.eval_proj_call(obj.as_ref().clone(), attr.clone(), args.clone(), &())
-                {
-                    if sup_p != &evaled {
+                    && sup_p != &evaled {
                         return self.supertype_of_tp(&evaled, sub_p, variance);
                     }
-                }
                 false
             }
             (_, TyParam::ProjCall { obj, attr, args }) => {
                 if let Ok(evaled) =
                     self.eval_proj_call(obj.as_ref().clone(), attr.clone(), args.clone(), &())
-                {
-                    if sub_p != &evaled {
+                    && sub_p != &evaled {
                         return self.supertype_of_tp(sup_p, &evaled, variance);
                     }
-                }
                 false
             }
             _ => {

--- a/crates/erg_compiler/context/eval.rs
+++ b/crates/erg_compiler/context/eval.rs
@@ -588,13 +588,11 @@ impl Context {
                     if let Ok(attr) = self.eval_attr(obj.clone(), &attr.ident) {
                         return Err((attr, err));
                     }
-                    if let Expr::Accessor(acc) = attr.obj.as_ref() {
-                        if let Some(mod_ctx) = self.get_mod_ctx_from_acc(acc) {
-                            if let Ok(obj) = mod_ctx.eval_const_ident(&attr.ident) {
+                    if let Expr::Accessor(acc) = attr.obj.as_ref()
+                        && let Some(mod_ctx) = self.get_mod_ctx_from_acc(acc)
+                            && let Ok(obj) = mod_ctx.eval_const_ident(&attr.ident) {
                                 return Ok(obj);
                             }
-                        }
-                    }
                     Err((obj, err))
                 }
             },
@@ -653,8 +651,8 @@ impl Context {
         if let Some(val) = obj.try_get_attr(&field) {
             return Ok(val);
         }
-        if let ValueObj::Type(t) = &obj {
-            if let Some(sups) = self.get_nominal_super_type_ctxs(t.typ()) {
+        if let ValueObj::Type(t) = &obj
+            && let Some(sups) = self.get_nominal_super_type_ctxs(t.typ()) {
                 for ctx in sups {
                     if let Some(val) = ctx.consts.get(ident.inspect()) {
                         return Ok(val.clone());
@@ -666,7 +664,6 @@ impl Context {
                     }
                 }
             }
-        }
         Err(EvalError::no_attr_error(
             self.cfg.input.clone(),
             line!() as usize,
@@ -2388,15 +2385,14 @@ impl Context {
                         }
                     };
                 }
-                if let Some(ValueObj::Subr(subr)) = self.rec_get_const_obj(&name) {
-                    if let Ok(args) = self.convert_args(None, subr, params.clone(), t_loc) {
+                if let Some(ValueObj::Subr(subr)) = self.rec_get_const_obj(&name)
+                    && let Ok(args) = self.convert_args(None, subr, params.clone(), t_loc) {
                         let ret = self.call(subr.clone(), args, t_loc);
                         if let Some(t) = ret.ok().and_then(|tp| self.convert_tp_into_type(tp).ok())
                         {
                             return Ok(t);
                         }
                     }
-                }
                 let t = poly(name, params);
                 if errs.is_empty() {
                     Ok(t)
@@ -2618,8 +2614,8 @@ impl Context {
                 }
             }
         }
-        if let Some((sub, sup)) = lhs.as_free().and_then(|fv| fv.get_subsup()) {
-            if self.is_trait(&sup) && !self.trait_impl_exists(&sub, &sup) {
+        if let Some((sub, sup)) = lhs.as_free().and_then(|fv| fv.get_subsup())
+            && self.is_trait(&sup) && !self.trait_impl_exists(&sub, &sup) {
                 // link to `Never..Obj` to prevent double errors from being reported
                 lhs.destructive_link(&bounded(Never, Type::Obj));
                 let sub = if cfg!(feature = "debug") {
@@ -2642,7 +2638,6 @@ impl Context {
                     self.get_simple_type_mismatch_hint(&sup, &sub),
                 )));
             }
-        }
         // if the target can't be found in the supertype, the type will be dereferenced.
         // In many cases, it is still better to determine the type variable than if the target is not found.
         let coerced = self.coerce(lhs.clone(), t_loc)?;
@@ -2676,11 +2671,10 @@ impl Context {
         if let Some(ctx) = lhs.qual_name().and_then(|name| {
             self.get_same_name_context(&name)
                 .or_else(|| self.get_mod(&name))
-        }) {
-            if let Some(value) = ctx.rec_get_const_obj(&rhs) {
+        })
+            && let Some(value) = ctx.rec_get_const_obj(&rhs) {
                 return Ok(TyParam::value(value.clone()));
             }
-        }
         let ty_ctxs = match self
             .get_tp_t(&lhs)
             .ok()
@@ -3856,9 +3850,9 @@ impl Context {
                 }
             }
         }
-        if let TyParam::FreeVar(fv) = &lhs {
-            if let Some((sub, sup)) = fv.get_subsup() {
-                if self.is_trait(&sup) && !self.trait_impl_exists(&sub, &sup) {
+        if let TyParam::FreeVar(fv) = &lhs
+            && let Some((sub, sup)) = fv.get_subsup()
+                && self.is_trait(&sup) && !self.trait_impl_exists(&sub, &sup) {
                     // to prevent double error reporting
                     lhs.destructive_link(&TyParam::t(Never));
                     let sub = if cfg!(feature = "debug") {
@@ -3881,8 +3875,6 @@ impl Context {
                         self.get_simple_type_mismatch_hint(&sup, &sub),
                     )));
                 }
-            }
-        }
         // if the target can't be found in the supertype, the type will be dereferenced.
         // In many cases, it is still better to determine the type variable than if the target is not found.
         let coerced = self.coerce_tp(lhs.clone(), t_loc)?;
@@ -3933,9 +3925,9 @@ impl Context {
                 }
             }
         }
-        if let TyParam::FreeVar(fv) = &lhs {
-            if let Some((sub, sup)) = fv.get_subsup() {
-                if self.is_trait(&sup) && !self.trait_impl_exists(&sub, &sup) {
+        if let TyParam::FreeVar(fv) = &lhs
+            && let Some((sub, sup)) = fv.get_subsup()
+                && self.is_trait(&sup) && !self.trait_impl_exists(&sub, &sup) {
                     // to prevent double error reporting
                     lhs.destructive_link(&TyParam::t(Never));
                     let sub = if cfg!(feature = "debug") {
@@ -3958,8 +3950,6 @@ impl Context {
                         self.get_simple_type_mismatch_hint(&sup, &sub),
                     )));
                 }
-            }
-        }
         // if the target can't be found in the supertype, the type will be dereferenced.
         // In many cases, it is still better to determine the type variable than if the target is not found.
         let coerced = self.coerce_tp(lhs.clone(), t_loc)?;
@@ -4286,15 +4276,13 @@ impl Context {
                 })
                 .or_else(|| {
                     let namespace = p.namespace();
-                    if let Some(namespace) = self.get_namespace(&namespace) {
-                        if namespace.name != self.name {
-                            if let Some(typ) = p.local_name().and_then(|name| {
+                    if let Some(namespace) = self.get_namespace(&namespace)
+                        && namespace.name != self.name
+                            && let Some(typ) = p.local_name().and_then(|name| {
                                 namespace.get_tp_t(&TyParam::app(name, args.clone())).ok()
                             }) {
                                 return Some(typ);
                             }
-                        }
-                    }
                     None
                 })
                 .ok_or_else(|| {

--- a/crates/erg_compiler/context/eval.rs
+++ b/crates/erg_compiler/context/eval.rs
@@ -940,7 +940,7 @@ impl Context {
                     )),
                 )
             }),
-            ConstSubr::Gen(gen) => gen.call(args, self).map_err(|mut e| {
+            ConstSubr::Gen(generator) => generator.call(args, self).map_err(|mut e| {
                 if e.core.loc.is_unknown() {
                     e.core.loc = loc.loc();
                 }

--- a/crates/erg_compiler/context/hint.rs
+++ b/crates/erg_compiler/context/hint.rs
@@ -97,18 +97,16 @@ impl Context {
                 }
             }
             (Type::Quantified(expt), Type::Subr(fnd)) => {
-                if let Type::Subr(expt) = expt.as_ref() {
-                    if let Some(hint) = self.get_subr_type_mismatch_hint(expt, fnd) {
+                if let Type::Subr(expt) = expt.as_ref()
+                    && let Some(hint) = self.get_subr_type_mismatch_hint(expt, fnd) {
                         return Some(hint);
                     }
-                }
             }
             (Type::Quantified(expt), Type::Quantified(fnd)) => {
-                if let (Type::Subr(expt), Type::Subr(fnd)) = (expt.as_ref(), fnd.as_ref()) {
-                    if let Some(hint) = self.get_subr_type_mismatch_hint(expt, fnd) {
+                if let (Type::Subr(expt), Type::Subr(fnd)) = (expt.as_ref(), fnd.as_ref())
+                    && let Some(hint) = self.get_subr_type_mismatch_hint(expt, fnd) {
                         return Some(hint);
                     }
-                }
             }
             (Type::Record(expt), Type::Record(fnd)) => {
                 if let Some(hint) = self.get_record_type_mismatch_hint(expt, fnd) {
@@ -214,14 +212,13 @@ impl Context {
         if missing.is_empty() {
             let mut mismatched = "".to_string();
             for (field, expected) in expected.iter() {
-                if let Some(found) = found.get(field) {
-                    if !self.supertype_of(expected, found) {
+                if let Some(found) = found.get(field)
+                    && !self.supertype_of(expected, found) {
                         if !mismatched.is_empty() {
                             mismatched.push_str(", ");
                         }
                         mismatched.push_str(&format!("{field}: {expected} but found {found}"));
                     }
-                }
             }
             if mismatched.is_empty() {
                 None

--- a/crates/erg_compiler/context/initialize/const_func.rs
+++ b/crates/erg_compiler/context/initialize/const_func.rs
@@ -110,11 +110,11 @@ pub(crate) fn inheritable_func(mut args: ValueArgs, _ctx: &Context) -> EvalValue
         .remove_left_or_key("Class")
         .ok_or_else(|| not_passed("Class"))?;
     match class {
-        ValueObj::Type(TypeObj::Generated(mut gen)) => {
-            if let Some(typ) = gen.impls_mut() {
+        ValueObj::Type(TypeObj::Generated(mut gen_type)) => {
+            if let Some(typ) = gen_type.impls_mut() {
                 match typ.as_mut().map(|x| x.as_mut()) {
-                    Some(TypeObj::Generated(gen)) => {
-                        *gen.typ_mut() = and(mem::take(gen.typ_mut()), mono("InheritableType"));
+                    Some(TypeObj::Generated(inner_gen)) => {
+                        *inner_gen.typ_mut() = and(mem::take(inner_gen.typ_mut()), mono("InheritableType"));
                     }
                     Some(TypeObj::Builtin { t, .. }) => {
                         *t = and(mem::take(t), mono("InheritableType"));
@@ -124,7 +124,7 @@ pub(crate) fn inheritable_func(mut args: ValueArgs, _ctx: &Context) -> EvalValue
                     }
                 }
             }
-            Ok(ValueObj::Type(TypeObj::Generated(gen)).into())
+            Ok(ValueObj::Type(TypeObj::Generated(gen_type)).into())
         }
         other => feature_error!(
             EvalValueError,

--- a/crates/erg_compiler/context/initialize/mod.rs
+++ b/crates/erg_compiler/context/initialize/mod.rs
@@ -785,13 +785,11 @@ impl Context {
         vis: Visibility,
         py_name: Option<&'static str>,
     ) {
-        if DEBUG_MODE {
-            if let Type::Subr(subr) = &t {
-                if subr.has_qvar() {
+        if DEBUG_MODE
+            && let Type::Subr(subr) = &t
+                && subr.has_qvar() {
                     panic!("not quantified subr: {subr}");
                 }
-            }
-        }
         let name = if PYTHON_MODE {
             if let Some(py_name) = py_name {
                 VarName::from_static(py_name)
@@ -831,13 +829,11 @@ impl Context {
         py_name: Option<&'static str>,
         loc: AbsLocation,
     ) {
-        if cfg!(feature = "debug") {
-            if let Type::Subr(subr) = &t {
-                if subr.has_qvar() {
+        if cfg!(feature = "debug")
+            && let Type::Subr(subr) = &t
+                && subr.has_qvar() {
                     panic!("not quantified subr: {subr}");
                 }
-            }
-        }
         let vi = VarInfo::new(
             t,
             muty,
@@ -942,17 +938,14 @@ impl Context {
         if self.rec_get_const_obj(name).is_some() {
             panic!("already registered: {} {name}", self.name);
         } else {
-            if DEBUG_MODE {
-                if let ValueObj::Subr(ConstSubr::Builtin(BuiltinConstSubr {
+            if DEBUG_MODE
+                && let ValueObj::Subr(ConstSubr::Builtin(BuiltinConstSubr {
                     sig_t: Type::Subr(subr),
                     ..
                 })) = &obj
-                {
-                    if subr.has_qvar() {
+                    && subr.has_qvar() {
                         panic!("not quantified subr: {subr}");
                     }
-                }
-            }
             let t = t.unwrap_or_else(|| v_enum(set! {obj.clone()}));
             // TODO: not all value objects are comparable
             let vi = VarInfo::new(
@@ -982,17 +975,14 @@ impl Context {
         if self.rec_get_const_obj(name).is_some() {
             panic!("already registered: {} {name}", self.name);
         } else {
-            if DEBUG_MODE {
-                if let ValueObj::Subr(ConstSubr::Builtin(BuiltinConstSubr {
+            if DEBUG_MODE
+                && let ValueObj::Subr(ConstSubr::Builtin(BuiltinConstSubr {
                     sig_t: Type::Subr(subr),
                     ..
                 })) = &obj
-                {
-                    if subr.has_qvar() {
+                    && subr.has_qvar() {
                         panic!("not quantified subr: {subr}");
                     }
-                }
-            }
             let t = t.unwrap_or_else(|| v_enum(set! {obj.clone()}));
             let loc = lineno
                 .map(|lineno| Location::range(lineno, 0, lineno, name.len() as u32))

--- a/crates/erg_compiler/context/inquire.rs
+++ b/crates/erg_compiler/context/inquire.rs
@@ -4174,10 +4174,10 @@ impl Context {
 
     fn _get_gen_t_require_attr_t<'a>(
         &'a self,
-        gen: &'a GenTypeObj,
+        gen_type: &'a GenTypeObj,
         attr: &str,
     ) -> Option<&'a Type> {
-        match gen.base_or_sup().map(|req_sup| req_sup.typ()) {
+        match gen_type.base_or_sup().map(|req_sup| req_sup.typ()) {
             Some(Type::Record(rec)) => {
                 if let Some(t) = rec.get(attr) {
                     return Some(t);
@@ -4192,12 +4192,10 @@ impl Context {
             }
             None => {}
         }
-        if let Some(additional) = gen.additional() {
-            if let Type::Record(gen) = additional.typ() {
-                if let Some(t) = gen.get(attr) {
+        if let Some(additional) = gen_type.additional()
+            && let Type::Record(rec) = additional.typ()
+                && let Some(t) = rec.get(attr) {
                     return Some(t);
-                }
-            }
                 }
         None
     }

--- a/crates/erg_compiler/context/inquire.rs
+++ b/crates/erg_compiler/context/inquire.rs
@@ -286,15 +286,12 @@ impl Context {
         match obj {
             hir::Expr::Accessor(hir::Accessor::Ident(ident)) => {
                 // e.g. ident.t: {Int}
-                if let Ok(refine) = <&RefinementType>::try_from(ident.ref_t()) {
-                    if let Predicate::Equal { rhs, .. } = refine.pred.as_ref() {
-                        if let Ok(t) = <&Type>::try_from(rhs) {
-                            if let Some(ctxs) = self.get_nominal_super_type_ctxs(t) {
+                if let Ok(refine) = <&RefinementType>::try_from(ident.ref_t())
+                    && let Predicate::Equal { rhs, .. } = refine.pred.as_ref()
+                        && let Ok(t) = <&Type>::try_from(rhs)
+                            && let Some(ctxs) = self.get_nominal_super_type_ctxs(t) {
                                 return Ok(ctxs.into_iter().map(|ctx| &ctx.ctx).collect());
                             }
-                        }
-                    }
-                }
                 self.get_singular_ctxs_by_ident(&ident.raw, namespace)
             }
             hir::Expr::Accessor(hir::Accessor::Attr(attr)) => {
@@ -605,8 +602,8 @@ impl Context {
         input: &Input,
         namespace: &Context,
     ) -> Triple<VarInfo, TyCheckError> {
-        if ident.inspect() == "Self" {
-            if let Some(self_t) = self.rec_get_self_t() {
+        if ident.inspect() == "Self"
+            && let Some(self_t) = self.rec_get_self_t() {
                 return self.rec_get_var_info(
                     &Identifier::auto(self_t.local_name()),
                     acc_kind,
@@ -614,7 +611,6 @@ impl Context {
                     namespace,
                 );
             }
-        }
         if let Some(vi) = self.get_current_scope_var(&ident.name) {
             match self.validate_visibility(ident, vi, input, namespace) {
                 Ok(()) if acc_kind.matches(vi) => {
@@ -666,14 +662,13 @@ impl Context {
                 Triple::None => {}
             }
         }
-        if acc_kind.is_local() {
-            if let Some(parent) = self
+        if acc_kind.is_local()
+            && let Some(parent) = self
                 .get_outer_scope()
                 .or_else(|| self.get_builtins_not_self())
             {
                 return parent.rec_get_var_info(ident, acc_kind, input, namespace);
             }
-        }
         Triple::None
     }
 
@@ -745,14 +740,13 @@ impl Context {
                 Triple::None => {}
             }
         }
-        if acc_kind.is_local() {
-            if let Some(parent) = self
+        if acc_kind.is_local()
+            && let Some(parent) = self
                 .get_outer_scope()
                 .or_else(|| self.get_builtins_not_self())
             {
                 return parent.rec_get_decl_info(ident, acc_kind, input, namespace);
             }
-        }
         Triple::None
     }
 
@@ -795,8 +789,8 @@ impl Context {
                 Constraint::new_subtype_of(t.clone())
             });
             let t = free_var(self.level, constraint);
-            if let Some(fv) = obj.ref_t().as_free() {
-                if let Some((_sub, sup)) = fv.get_subsup() {
+            if let Some(fv) = obj.ref_t().as_free()
+                && let Some((_sub, sup)) = fv.get_subsup() {
                     let vis = self
                         .instantiate_vis_modifier(&ident.vis)
                         .unwrap_or(VisibilityModifier::Public);
@@ -809,7 +803,6 @@ impl Context {
                         obj.ref_t().update_super(intersection, None, true);
                     }
                 }
-            }
             let muty = Mutability::from(&ident.inspect()[..]);
             let vi = VarInfo::new(
                 t,
@@ -920,8 +913,8 @@ impl Context {
         namespace: &Context,
         expect: Option<&Type>,
     ) -> Triple<VarInfo, TyCheckError> {
-        if let Ok(coerced) = self.coerce(obj.t(), &obj) {
-            if &coerced != obj.ref_t() {
+        if let Ok(coerced) = self.coerce(obj.t(), &obj)
+            && &coerced != obj.ref_t() {
                 let hash = get_hash(obj.ref_t());
                 let list = UndoableLinkedList::new();
                 obj.ref_t().undoable_coerce(&list);
@@ -934,7 +927,6 @@ impl Context {
                     return Triple::Ok(vi);
                 }
             }
-        }
         Triple::None
     }
 
@@ -1262,8 +1254,8 @@ impl Context {
                     }
                     _ => {}
                 }
-                if self.subtype_of(ty, &input_t) {
-                    if let Ok(instance) = self.instantiate(ty.clone(), obj) {
+                if self.subtype_of(ty, &input_t)
+                    && let Ok(instance) = self.instantiate(ty.clone(), obj) {
                         let subst = self
                             .substitute_call(
                                 obj,
@@ -1281,7 +1273,6 @@ impl Context {
                             return Ok(ty.clone());
                         }
                     }
-                }
             }
             if let Some(default) = instance.default_intersection_type() {
                 debug_assert!(!default.is_intersection_type());
@@ -1378,8 +1369,8 @@ impl Context {
                 .collect::<Vec<_>>();
             let return_t = free_var(self.level, Constraint::new_type_of(Type));
             let mut subr_t = fn_met(obj.t(), nd_params, None, d_params, None, return_t);
-            if let Some(fv) = obj.ref_t().as_free() {
-                if let Some((_sub, sup)) = fv.get_subsup() {
+            if let Some(fv) = obj.ref_t().as_free()
+                && let Some((_sub, sup)) = fv.get_subsup() {
                     // avoid recursion
                     *subr_t.mut_self_t().unwrap() = Failure;
                     let vis = self
@@ -1394,7 +1385,6 @@ impl Context {
                         obj.ref_t().update_super(intersection, None, true);
                     }
                 }
-            }
             let muty = Mutability::from(&attr_name.inspect()[..]);
             let vi = VarInfo::new(
                 subr_t,
@@ -1887,11 +1877,10 @@ impl Context {
                 {
                     log!(info "~> {after}\n");
                     *self_t = *after.clone();
-                    if let Some(ident) = receiver.as_ident() {
-                        if let Some(vi) = self.rec_get_mut_var_info(&ident.raw, AccessKind::Name) {
+                    if let Some(ident) = receiver.as_ident()
+                        && let Some(vi) = self.rec_get_mut_var_info(&ident.raw, AccessKind::Name) {
                             vi.t = self_t.clone();
                         }
-                    }
                 }
             }
             Ok(())
@@ -2234,11 +2223,10 @@ impl Context {
                 .iter()
                 .filter(|pt| pt.name().is_some_and(|name| !passed_params.contains(name)))
             {
-                if let ParamTy::KwWithDefault { ty, default, .. } = &not_passed {
-                    if let Err(mut es) = self.sub_unify(default, ty, obj, not_passed.name()) {
+                if let ParamTy::KwWithDefault { ty, default, .. } = &not_passed
+                    && let Err(mut es) = self.sub_unify(default, ty, obj, not_passed.name()) {
                         errs.append(&mut es);
                     }
-                }
             }
         } else {
             let mut nth = 1;
@@ -2284,8 +2272,8 @@ impl Context {
                         .into()
                 })
                 .collect::<Vec<_>>();
-            if let Some(var_args) = var_args {
-                if !self.subtype_of(
+            if let Some(var_args) = var_args
+                && !self.subtype_of(
                     var_args.expr.ref_t(),
                     &poly("Iterable", vec![TyParam::t(Obj)]),
                 ) {
@@ -2303,9 +2291,8 @@ impl Context {
                     );
                     errs.push(err);
                 }
-            }
-            if let Some(kw_var_args) = kw_var_args {
-                if !self.subtype_of(
+            if let Some(kw_var_args) = kw_var_args
+                && !self.subtype_of(
                     kw_var_args.expr.ref_t(),
                     &poly("Mapping", vec![TyParam::t(Obj), TyParam::t(Obj)]),
                 ) {
@@ -2323,7 +2310,6 @@ impl Context {
                     );
                     errs.push(err);
                 }
-            }
             if missing_params.is_empty() && (var_args.is_some() || kw_var_args.is_some()) {
                 return Err(TyCheckErrors::from(TyCheckError::too_many_args_error(
                     self.cfg.input.clone(),
@@ -2790,8 +2776,8 @@ impl Context {
         input: &Input,
         namespace: &Context,
     ) -> FailableOption<VarInfo> {
-        if let Some(local) = obj.as_ident() {
-            if local.vis().is_private() {
+        if let Some(local) = obj.as_ident()
+            && local.vis().is_private() {
                 match &local.inspect()[..] {
                     "match" => {
                         return self.get_match_call_t(SubrKind::Func, pos_args, kw_args);
@@ -2802,7 +2788,6 @@ impl Context {
                     _ => {}
                 }
             }
-        }
         let found = self
             .search_callee_info(
                 obj,
@@ -3084,11 +3069,10 @@ impl Context {
                 if let Some(prev) = free.get_undoable_root() {
                     return prev.unbound_name().as_ref() == Some(name.inspect());
                 }
-            } else if let Ok(free) = <&FreeTyVar>::try_from(tp) {
-                if let Some(prev) = free.get_undoable_root() {
+            } else if let Ok(free) = <&FreeTyVar>::try_from(tp)
+                && let Some(prev) = free.get_undoable_root() {
                     return prev.unbound_name().as_ref() == Some(name.inspect());
                 }
-            }
             tp.qual_name().as_ref() == Some(name.inspect())
         };
         let in_inout = |t: &Type, name: &VarName| {
@@ -3428,11 +3412,9 @@ impl Context {
                     rhs: TyParam::Value(ValueObj::Type(typ)),
                     ..
                 } = refine.pred.as_ref()
-                {
-                    if let Some(res) = self.get_nominal_type_ctx(typ.typ()) {
+                    && let Some(res) = self.get_nominal_type_ctx(typ.typ()) {
                         return Some(res);
                     }
-                }
                 if let Some(res) = self.get_nominal_type_ctx(&refine.t) {
                     return Some(res);
                 }
@@ -3452,15 +3434,13 @@ impl Context {
                 } else if self
                     .get_nominal_type_ctx(quant)
                     .is_some_and(|ctx| &ctx.typ.qual_name() == "FuncMetaType")
-                {
-                    if let Some(ctx) = self
+                    && let Some(ctx) = self
                         .get_builtins_not_self()
                         .unwrap_or(self)
                         .rec_local_get_mono_type("QuantifiedFuncMetaType")
                     {
                         return Some(ctx);
                     }
-                }
                 if let Some(ctx) = self
                     .get_builtins_not_self()
                     .unwrap_or(self)
@@ -3471,15 +3451,14 @@ impl Context {
             }
             Type::Subr(subr) => match subr.kind {
                 SubrKind::Func => {
-                    if self.subtype_of(&subr.return_t, &Type) {
-                        if let Some(ctx) = self
+                    if self.subtype_of(&subr.return_t, &Type)
+                        && let Some(ctx) = self
                             .get_builtins_not_self()
                             .unwrap_or(self)
                             .rec_local_get_mono_type("FuncMetaType")
                         {
                             return Some(ctx);
                         }
-                    }
                     if let Some(ctx) = self
                         .get_builtins_not_self()
                         .unwrap_or(self)
@@ -3489,15 +3468,14 @@ impl Context {
                     }
                 }
                 SubrKind::Proc => {
-                    if self.subtype_of(&subr.return_t, &Type) {
-                        if let Some(ctx) = self
+                    if self.subtype_of(&subr.return_t, &Type)
+                        && let Some(ctx) = self
                             .get_builtins_not_self()
                             .unwrap_or(self)
                             .rec_local_get_mono_type("ProcMetaType")
                         {
                             return Some(ctx);
                         }
-                    }
                     if let Some(ctx) = self
                         .get_builtins_not_self()
                         .unwrap_or(self)
@@ -3514,15 +3492,14 @@ impl Context {
                 return self.get_poly_type(name);
             }
             Type::Record(rec) => {
-                if rec.values().all(|t| self.subtype_of(t, &Type)) {
-                    if let Some(ctx) = self
+                if rec.values().all(|t| self.subtype_of(t, &Type))
+                    && let Some(ctx) = self
                         .get_builtins_not_self()
                         .unwrap_or(self)
                         .rec_local_get_mono_type("RecordMetaType")
                     {
                         return Some(ctx);
                     }
-                }
                 return self
                     .get_builtins_not_self()
                     .unwrap_or(self)
@@ -3559,11 +3536,10 @@ impl Context {
                 }
             }
             Type::Proj { lhs, rhs } => {
-                if let Ok(evaled) = self.eval_proj(*lhs.clone(), rhs.clone(), self.level, &()) {
-                    if typ != &evaled {
+                if let Ok(evaled) = self.eval_proj(*lhs.clone(), rhs.clone(), self.level, &())
+                    && typ != &evaled {
                         return self.get_nominal_type_ctx(&evaled);
                     }
-                }
             }
             Type::ProjCall {
                 lhs,
@@ -3576,11 +3552,10 @@ impl Context {
                     args.clone(),
                     self.level,
                     &(),
-                ) {
-                    if typ != &evaled {
+                )
+                    && typ != &evaled {
                         return self.get_nominal_type_ctx(&evaled);
                     }
-                }
             }
             other => {
                 log!("{other} has no nominal definition");
@@ -3646,11 +3621,10 @@ impl Context {
                 }
             }
             Type::Proj { lhs, rhs } => {
-                if let Ok(evaled) = self.eval_proj(*lhs.clone(), rhs.clone(), self.level, &()) {
-                    if typ != &evaled {
+                if let Ok(evaled) = self.eval_proj(*lhs.clone(), rhs.clone(), self.level, &())
+                    && typ != &evaled {
                         return self.get_mut_nominal_type_ctx(&evaled);
                     }
-                }
             }
             Type::ProjCall {
                 lhs,
@@ -3663,11 +3637,10 @@ impl Context {
                     args.clone(),
                     self.level,
                     &(),
-                ) {
-                    if typ != &evaled {
+                )
+                    && typ != &evaled {
                         return self.get_mut_nominal_type_ctx(&evaled);
                     }
-                }
             }
             other => {
                 log!("{other} has no nominal definition");
@@ -3756,11 +3729,10 @@ impl Context {
         }
         #[cfg(feature = "py_compat")]
         let name = self.erg_to_py_names.get(name).map_or(name, |s| &s[..]);
-        if name == "Self" {
-            if let Some(ty) = self.rec_get_self_t() {
+        if name == "Self"
+            && let Some(ty) = self.rec_get_self_t() {
                 return self.rec_get_const_obj(&ty.local_name());
             }
-        }
         if let Some(val) = self.consts.get(name) {
             return Some(val);
         }
@@ -3847,16 +3819,14 @@ impl Context {
             return Some(ctx);
         }
         let typ = Type::Mono(Str::rc(name));
-        if self.name.starts_with(&typ.namespace()[..]) {
-            if let Some(ctx) = self.rec_local_get_mono_type(&typ.local_name()) {
+        if self.name.starts_with(&typ.namespace()[..])
+            && let Some(ctx) = self.rec_local_get_mono_type(&typ.local_name()) {
                 return Some(ctx);
             }
-        }
-        if let Some(ctx) = self.get_namespace(&typ.namespace()) {
-            if let Some(ctx) = ctx.rec_local_get_mono_type(&typ.local_name()) {
+        if let Some(ctx) = self.get_namespace(&typ.namespace())
+            && let Some(ctx) = ctx.rec_local_get_mono_type(&typ.local_name()) {
                 return Some(ctx);
             }
-        }
         None
     }
 
@@ -3890,16 +3860,14 @@ impl Context {
             return Some(ctx);
         }
         let typ = Type::Mono(Str::rc(name));
-        if self.name.starts_with(&typ.namespace()[..]) {
-            if let Some(ctx) = self.rec_local_get_poly_type(&typ.local_name()) {
+        if self.name.starts_with(&typ.namespace()[..])
+            && let Some(ctx) = self.rec_local_get_poly_type(&typ.local_name()) {
                 return Some(ctx);
             }
-        }
-        if let Some(ctx) = self.get_namespace(&typ.namespace()) {
-            if let Some(ctx) = ctx.rec_local_get_poly_type(&typ.local_name()) {
+        if let Some(ctx) = self.get_namespace(&typ.namespace())
+            && let Some(ctx) = ctx.rec_local_get_poly_type(&typ.local_name()) {
                 return Some(ctx);
             }
-        }
         None
     }
 
@@ -3947,16 +3915,14 @@ impl Context {
             return Some(ctx);
         }
         let typ = Type::Mono(Str::rc(name));
-        if self.name.starts_with(&typ.namespace()[..]) {
-            if let Some(ctx) = self.rec_local_get_type(&typ.local_name()) {
+        if self.name.starts_with(&typ.namespace()[..])
+            && let Some(ctx) = self.rec_local_get_type(&typ.local_name()) {
                 return Some(ctx);
             }
-        }
-        if let Some(ctx) = self.get_namespace(&typ.namespace()) {
-            if let Some(ctx) = ctx.rec_local_get_type(&typ.local_name()) {
+        if let Some(ctx) = self.get_namespace(&typ.namespace())
+            && let Some(ctx) = ctx.rec_local_get_type(&typ.local_name()) {
                 return Some(ctx);
             }
-        }
         None
     }
 
@@ -4232,7 +4198,7 @@ impl Context {
                     return Some(t);
                 }
             }
-        }
+                }
         None
     }
 
@@ -4549,16 +4515,14 @@ impl Context {
     }
 
     pub(crate) fn get_instance_attr(&self, name: &str) -> Option<&VarInfo> {
-        if let Some(vi) = self.locals.get(name) {
-            if vi.kind.is_instance_attr() {
+        if let Some(vi) = self.locals.get(name)
+            && vi.kind.is_instance_attr() {
                 return Some(vi);
             }
-        }
-        if let Some(vi) = self.decls.get(name) {
-            if vi.kind.is_instance_attr() {
+        if let Some(vi) = self.decls.get(name)
+            && vi.kind.is_instance_attr() {
                 return Some(vi);
             }
-        }
         if self.kind.is_method_def() {
             self.get_nominal_type_ctx(&mono(&self.name))
                 .and_then(|ctx| ctx.get_instance_attr(name))
@@ -4609,11 +4573,10 @@ impl Context {
             if !v.kind.is_instance_attr() {
                 return Some((k, v));
             }
-        } else if let Some((k, v)) = self.decls.get_key_value(name) {
-            if !v.kind.is_instance_attr() {
+        } else if let Some((k, v)) = self.decls.get_key_value(name)
+            && !v.kind.is_instance_attr() {
                 return Some((k, v));
             }
-        }
         if self.kind.is_method_def() {
             self.get_nominal_type_ctx(&mono(&self.name))
                 .and_then(|ctx| ctx.get_class_attr(name))

--- a/crates/erg_compiler/context/instantiate.rs
+++ b/crates/erg_compiler/context/instantiate.rs
@@ -721,11 +721,11 @@ impl Context {
                     builtin.sig_t = t;
                     Ok(ValueObj::Subr(ConstSubr::Builtin(builtin)))
                 }
-                ConstSubr::Gen(mut gen) => {
-                    let t = mem::take(&mut gen.sig_t);
+                ConstSubr::Gen(mut generator) => {
+                    let t = mem::take(&mut generator.sig_t);
                     let t = self.instantiate_t_inner(t, tmp_tv_cache, loc)?;
-                    gen.sig_t = t;
-                    Ok(ValueObj::Subr(ConstSubr::Gen(gen)))
+                    generator.sig_t = t;
+                    Ok(ValueObj::Subr(ConstSubr::Gen(generator)))
                 }
                 ConstSubr::User(mut user) => {
                     let t = mem::take(&mut user.sig_t);

--- a/crates/erg_compiler/context/instantiate_spec.rs
+++ b/crates/erg_compiler/context/instantiate_spec.rs
@@ -642,8 +642,8 @@ impl Context {
                     .map_err(|errs| (Type::Failure, errs)),
             },
             ast::PreDeclTypeSpec::Attr { namespace, t } => {
-                if let Ok(receiver) = Parser::validate_const_expr(namespace.as_ref().clone()) {
-                    if let Ok(receiver_t) = self.instantiate_const_expr_as_type(
+                if let Ok(receiver) = Parser::validate_const_expr(namespace.as_ref().clone())
+                    && let Ok(receiver_t) = self.instantiate_const_expr_as_type(
                         &receiver,
                         None,
                         tmp_tv_cache,
@@ -653,7 +653,6 @@ impl Context {
                             .eval_proj(receiver_t, t.inspect().clone(), self.level, predecl)
                             .map_err(|errs| (Type::Failure, errs));
                     }
-                }
                 let ctxs = self
                     .get_singular_ctxs(namespace.as_ref(), self)
                     .map_err(|errs| (Type::Failure, errs.into()))?;
@@ -757,8 +756,8 @@ impl Context {
                     }
                     return self.check_mono_type(typ, ident);
                 }
-                if let Some(outer) = &self.outer {
-                    if let Ok(t) = outer.instantiate_mono_t(
+                if let Some(outer) = &self.outer
+                    && let Ok(t) = outer.instantiate_mono_t(
                         ident,
                         opt_decl_pt,
                         tmp_tv_cache,
@@ -766,7 +765,6 @@ impl Context {
                     ) {
                         return Ok(t);
                     }
-                }
                 if let Some(ctx) = self.get_type_ctx(ident.inspect()) {
                     if let Some((_, vi)) = self.get_var_info(ident.inspect()) {
                         self.inc_ref(ident.inspect(), vi, ident, self);
@@ -1053,8 +1051,8 @@ impl Context {
                         .and_then(|v| ctx_of_type.convert_value_into_type(v.clone()).ok())
                         .and_then(|typ| ctx_of_type.get_nominal_type_ctx(&typ))
                 }) else {
-                    if let Some(outer) = &self.outer {
-                        if let Ok(t) = outer.instantiate_local_poly_t(
+                    if let Some(outer) = &self.outer
+                        && let Ok(t) = outer.instantiate_local_poly_t(
                             name,
                             args,
                             outer,
@@ -1064,7 +1062,6 @@ impl Context {
                         ) {
                             return Ok(t);
                         }
-                    }
                     if let Some(decl_t) = opt_decl_t {
                         return Ok(decl_t.typ().clone());
                     }
@@ -1347,12 +1344,11 @@ impl Context {
             tmp_tv_cache.push_or_init_tyvar(&name.name, &tyvar, self)?;
             return Ok(TyParam::t(tyvar));
         }
-        if name.is_const() {
-            if let Some((_, vi)) = self.get_var_info(name.inspect()) {
+        if name.is_const()
+            && let Some((_, vi)) = self.get_var_info(name.inspect()) {
                 self.inc_ref(name.inspect(), vi, name, self);
                 return Ok(TyParam::mono(name.inspect()));
             }
-        }
         Err(TyCheckErrors::from(TyCheckError::no_var_error(
             self.cfg.input.clone(),
             line!() as usize,
@@ -1521,11 +1517,10 @@ impl Context {
                     tmp_tv_cache,
                     not_found_is_qvar,
                 )?;
-                if length.is_erased() {
-                    if let Ok(elem_t) = self.instantiate_tp_as_type(elem, lis) {
+                if length.is_erased()
+                    && let Ok(elem_t) = self.instantiate_tp_as_type(elem, lis) {
                         return Ok(TyParam::t(unknown_len_list_t(elem_t)));
                     }
-                }
                 type_feature_error!(
                     self,
                     lis.loc(),

--- a/crates/erg_compiler/context/mod.rs
+++ b/crates/erg_compiler/context/mod.rs
@@ -1590,12 +1590,11 @@ impl Context {
             for ((tp, arg), arg_t) in ctx.typ.typarams().iter().zip(args.pos_args()).zip(arg_ts) {
                 let tp = self.detach_tp(tp.clone(), &mut tv_ctx);
                 if let Some(ident) = &arg.expr.as_ident() {
-                    if self.subtype_of(arg_t, &Type::Type) {
-                        if let Ok(tv) = self.convert_tp_into_type(tp.clone()) {
+                    if self.subtype_of(arg_t, &Type::Type)
+                        && let Ok(tv) = self.convert_tp_into_type(tp.clone()) {
                             let _ = tv_ctx.push_or_init_tyvar(&ident.name, &tv, self);
                             continue;
                         }
-                    }
                     let _ = tv_ctx.push_or_init_typaram(&ident.name, &tp, self);
                 }
             }

--- a/crates/erg_compiler/context/register.rs
+++ b/crates/erg_compiler/context/register.rs
@@ -1896,11 +1896,11 @@ impl Context {
         } else {
             match obj {
                 ValueObj::Type(t) => match t {
-                    TypeObj::Generated(gen) if alias => {
-                        let meta_t = gen.meta_type();
-                        self.register_type_alias(ident, gen.into_typ(), meta_t)
+                    TypeObj::Generated(generator) if alias => {
+                        let meta_t = generator.meta_type();
+                        self.register_type_alias(ident, generator.into_typ(), meta_t)
                     }
-                    TypeObj::Generated(gen) => self.register_gen_type(ident, gen, call),
+                    TypeObj::Generated(generator) => self.register_gen_type(ident, generator, call),
                     TypeObj::Builtin { t, meta_t } => self.register_type_alias(ident, t, meta_t),
                 },
                 // TODO: not all value objects are comparable
@@ -1928,25 +1928,25 @@ impl Context {
     pub(crate) fn register_gen_type(
         &mut self,
         ident: &Identifier,
-        gen: GenTypeObj,
+        generator: GenTypeObj,
         call: Option<&ast::Call>,
     ) -> CompileResult<()> {
-        match gen {
+        match generator {
             GenTypeObj::Class(_) => {
-                if gen.typ().is_monomorphic() {
-                    // let super_traits = gen.impls.iter().map(|to| to.typ().clone()).collect();
+                if generator.typ().is_monomorphic() {
+                    // let super_traits = generator.impls.iter().map(|to| to.typ().clone()).collect();
                     let mut ctx = Self::mono_class(
-                        gen.typ().qual_name(),
+                        generator.typ().qual_name(),
                         self.cfg.clone(),
                         self.shared.clone(),
                         2,
                         self.level,
                     );
-                    let res = self.gen_class_new_method(&gen, call, &mut ctx);
-                    let res2 = self.register_gen_mono_type(ident, gen, ctx, Const);
+                    let res = self.gen_class_new_method(&generator, call, &mut ctx);
+                    let res2 = self.register_gen_mono_type(ident, generator, ctx, Const);
                     concat_result(res, res2)
                 } else {
-                    let params = gen
+                    let params = generator
                         .typ()
                         .typarams()
                         .into_iter()
@@ -1956,23 +1956,23 @@ impl Context {
                         })
                         .collect();
                     let mut ctx = Self::poly_class(
-                        gen.typ().qual_name(),
+                        generator.typ().qual_name(),
                         params,
                         self.cfg.clone(),
                         self.shared.clone(),
                         2,
                         self.level,
                     );
-                    let res = self.gen_class_new_method(&gen, call, &mut ctx);
-                    let res2 = self.register_gen_poly_type(ident, gen, ctx, Const);
+                    let res = self.gen_class_new_method(&generator, call, &mut ctx);
+                    let res2 = self.register_gen_poly_type(ident, generator, ctx, Const);
                     concat_result(res, res2)
                 }
             }
-            GenTypeObj::Subclass(_) => self.register_gen_subclass(ident, gen, call),
+            GenTypeObj::Subclass(_) => self.register_gen_subclass(ident, generator, call),
             GenTypeObj::Trait(_) => {
-                if gen.typ().is_monomorphic() {
+                if generator.typ().is_monomorphic() {
                     let mut ctx = Self::mono_trait(
-                        gen.typ().qual_name(),
+                        generator.typ().qual_name(),
                         self.cfg.clone(),
                         self.shared.clone(),
                         2,
@@ -1981,13 +1981,13 @@ impl Context {
                     let res = if let Some(TypeObj::Builtin {
                         t: Type::Record(req),
                         ..
-                    }) = gen.base_or_sup()
+                    }) = generator.base_or_sup()
                     {
                         self.register_instance_attrs(&mut ctx, req, call)
                     } else {
                         Ok(())
                     };
-                    let res2 = self.register_gen_mono_type(ident, gen, ctx, Const);
+                    let res2 = self.register_gen_mono_type(ident, generator, ctx, Const);
                     concat_result(res, res2)
                 } else {
                     feature_error!(
@@ -2000,11 +2000,13 @@ impl Context {
                 }
             }
             GenTypeObj::Subtrait(_) => {
-                if gen.typ().is_monomorphic() {
-                    let super_classes = gen.base_or_sup().map_or(vec![], |t| vec![t.typ().clone()]);
-                    // let super_traits = gen.impls.iter().map(|to| to.typ().clone()).collect();
+                if generator.typ().is_monomorphic() {
+                    let super_classes = generator
+                        .base_or_sup()
+                        .map_or(vec![], |t| vec![t.typ().clone()]);
+                    // let super_traits = generator.impls.iter().map(|to| to.typ().clone()).collect();
                     let mut ctx = Self::mono_trait(
-                        gen.typ().qual_name(),
+                        generator.typ().qual_name(),
                         self.cfg.clone(),
                         self.shared.clone(),
                         2,
@@ -2013,7 +2015,7 @@ impl Context {
                     let additional = if let Some(TypeObj::Builtin {
                         t: Type::Record(additional),
                         ..
-                    }) = gen.additional()
+                    }) = generator.additional()
                     {
                         Some(additional)
                     } else {
@@ -2031,7 +2033,7 @@ impl Context {
                             log!(err "{sup} not found");
                         }
                     }
-                    let res2 = self.register_gen_mono_type(ident, gen, ctx, Const);
+                    let res2 = self.register_gen_mono_type(ident, generator, ctx, Const);
                     concat_result(res, res2)
                 } else {
                     feature_error!(
@@ -2044,19 +2046,19 @@ impl Context {
                 }
             }
             GenTypeObj::Patch(_) => {
-                if gen.typ().is_monomorphic() {
-                    let Some(TypeObj::Builtin { t: base, .. }) = gen.base_or_sup() else {
-                        todo!("{gen}")
+                if generator.typ().is_monomorphic() {
+                    let Some(TypeObj::Builtin { t: base, .. }) = generator.base_or_sup() else {
+                        todo!("{generator}")
                     };
                     let ctx = Self::mono_patch(
-                        gen.typ().qual_name(),
+                        generator.typ().qual_name(),
                         base.clone(),
                         self.cfg.clone(),
                         self.shared.clone(),
                         2,
                         self.level,
                     );
-                    self.register_gen_mono_patch(ident, gen, ctx, Const)
+                    self.register_gen_mono_patch(ident, generator, ctx, Const)
                 } else {
                     feature_error!(
                         CompileErrors,
@@ -2080,15 +2082,17 @@ impl Context {
     fn register_gen_subclass(
         &mut self,
         ident: &Identifier,
-        gen: GenTypeObj,
+        generator: GenTypeObj,
         call: Option<&ast::Call>,
     ) -> CompileResult<()> {
         let mut errs = CompileErrors::empty();
-        if gen.typ().is_monomorphic() {
-            let super_classes = gen.base_or_sup().map_or(vec![], |t| vec![t.typ().clone()]);
-            // let super_traits = gen.impls.iter().map(|to| to.typ().clone()).collect();
+        if generator.typ().is_monomorphic() {
+            let super_classes = generator
+                .base_or_sup()
+                .map_or(vec![], |t| vec![t.typ().clone()]);
+            // let super_traits = generator.impls.iter().map(|to| to.typ().clone()).collect();
             let mut ctx = Self::mono_class(
-                gen.typ().qual_name(),
+                generator.typ().qual_name(),
                 self.cfg.clone(),
                 self.shared.clone(),
                 2,
@@ -2117,7 +2121,7 @@ impl Context {
             }
             let mut methods =
                 Self::methods(None, self.cfg.clone(), self.shared.clone(), 2, self.level);
-            if let Some(sup) = gen.base_or_sup() {
+            if let Some(sup) = generator.base_or_sup() {
                 let param_t = match sup {
                     TypeObj::Builtin { t, .. } => Some(t),
                     TypeObj::Generated(t) => t.base_or_sup().map(|t| t.typ()),
@@ -2125,7 +2129,7 @@ impl Context {
                 let invalid_fields = if let Some(TypeObj::Builtin {
                     t: Type::Record(rec),
                     ..
-                }) = gen.additional()
+                }) = generator.additional()
                 {
                     if let Err((fields, es)) =
                         self.check_subtype_instance_attrs(sup.typ(), rec, call)
@@ -2142,15 +2146,13 @@ impl Context {
                 // => `Self.Requirement := {x = Int; y = Int}`
                 let call_t = {
                     let (nd_params, var_params, d_params, kw_var_params) =
-                        if let Some(additional) = gen.additional() {
+                        if let Some(additional) = generator.additional() {
                             if let TypeObj::Builtin {
                                 t: Type::Record(rec),
                                 ..
                             } = additional
-                            {
-                                if let Err(es) = self.register_instance_attrs(&mut ctx, rec, call) {
+                                && let Err(es) = self.register_instance_attrs(&mut ctx, rec, call) {
                                     errs.extend(es);
-                                }
                                 }
                             let param_t = if let Some(Type::Record(rec)) = param_t {
                                 let mut rec = rec.clone();
@@ -2184,12 +2186,12 @@ impl Context {
                         var_params,
                         d_params,
                         kw_var_params,
-                        gen.typ().clone(),
+                        generator.typ().clone(),
                     )
                 };
                 let new_t = {
                     let (nd_params, var_params, d_params, kw_var_params) = if let Some(additional) =
-                        gen.additional()
+                        generator.additional()
                     {
                         let param_t = if let Some(Type::Record(rec)) = param_t {
                             let mut rec = rec.clone();
@@ -2226,7 +2228,7 @@ impl Context {
                         var_params,
                         d_params,
                         kw_var_params,
-                        gen.typ().clone(),
+                        generator.typ().clone(),
                     )
                 };
                 if PYTHON_MODE {
@@ -2262,19 +2264,15 @@ impl Context {
                 }
                 ctx.methods_list.push(MethodContext::new(
                     DefId(0),
-                    ClassDefType::Simple(gen.typ().clone()),
+                    ClassDefType::Simple(generator.typ().clone()),
                     methods,
                 ));
-                if let Err(es) = self.register_gen_mono_type(ident, gen, ctx, Const) {
+                if let Err(es) = self.register_gen_mono_type(ident, generator, ctx, Const) {
                     errs.extend(es);
                 }
-                if errs.is_empty() {
-                    Ok(())
+                if errs.is_empty() { Ok(()) } else { Err(errs) }
             } else {
-                    Err(errs)
-                }
-            } else {
-                let class_name = gen
+                let class_name = generator
                     .base_or_sup()
                     .map(|t| t.typ().local_name())
                     .unwrap_or(Str::from("?"));
@@ -2409,12 +2407,12 @@ impl Context {
 
     fn gen_class_new_method(
         &self,
-        gen: &GenTypeObj,
+        generator: &GenTypeObj,
         call: Option<&ast::Call>,
         ctx: &mut Context,
     ) -> CompileResult<()> {
         let mut methods = Self::methods(None, self.cfg.clone(), self.shared.clone(), 2, self.level);
-        let new_t = if let Some(base) = gen.base_or_sup() {
+        let new_t = if let Some(base) = generator.base_or_sup() {
             match base {
                 TypeObj::Builtin {
                     t: Type::Record(rec),
@@ -2432,9 +2430,9 @@ impl Context {
                     )?;
                 }
             }
-            func1(base.typ().clone(), gen.typ().clone())
+            func1(base.typ().clone(), generator.typ().clone())
         } else {
-            func0(gen.typ().clone())
+            func0(generator.typ().clone())
         };
         if ERG_MODE {
             methods.register_fixed_auto_impl(
@@ -2463,7 +2461,7 @@ impl Context {
         }
         ctx.methods_list.push(MethodContext::new(
             DefId(0),
-            ClassDefType::Simple(gen.typ().clone()),
+            ClassDefType::Simple(generator.typ().clone()),
             methods,
         ));
         Ok(())
@@ -2513,7 +2511,7 @@ impl Context {
     fn register_gen_mono_type(
         &mut self,
         ident: &Identifier,
-        gen: GenTypeObj,
+        generator: GenTypeObj,
         ctx: Self,
         muty: Mutability,
     ) -> CompileResult<()> {
@@ -2531,8 +2529,8 @@ impl Context {
                 ident.inspect(),
             )))
         } else {
-            let t = gen.typ().clone();
-            let val = ValueObj::Type(TypeObj::Generated(gen));
+            let t = generator.typ().clone();
+            let val = ValueObj::Type(TypeObj::Generated(generator));
             let meta_t = v_enum(set! { val.clone() });
             let name = &ident.name;
             let id = DefId(get_hash(&(&self.name, &name)));
@@ -2559,7 +2557,7 @@ impl Context {
     fn register_gen_poly_type(
         &mut self,
         ident: &Identifier,
-        gen: GenTypeObj,
+        generator: GenTypeObj,
         ctx: Self,
         muty: Mutability,
     ) -> CompileResult<()> {
@@ -2576,8 +2574,8 @@ impl Context {
                 ident.inspect(),
             )))
         } else {
-            let t = gen.typ().clone();
-            let val = ValueObj::Type(TypeObj::Generated(gen));
+            let t = generator.typ().clone();
+            let val = ValueObj::Type(TypeObj::Generated(generator));
             let params = t
                 .typarams()
                 .into_iter()
@@ -2614,7 +2612,7 @@ impl Context {
     fn register_gen_mono_patch(
         &mut self,
         ident: &Identifier,
-        gen: GenTypeObj,
+        generator: GenTypeObj,
         ctx: Self,
         muty: Mutability,
     ) -> CompileResult<()> {
@@ -2637,8 +2635,8 @@ impl Context {
                 ident.inspect(),
             )))
         } else {
-            let t = gen.typ().clone();
-            let meta_t = gen.meta_type();
+            let t = generator.typ().clone();
+            let meta_t = generator.meta_type();
             let name = &ident.name;
             let id = DefId(get_hash(&(&self.name, &name)));
             self.decls.insert(
@@ -2655,7 +2653,7 @@ impl Context {
                 ),
             );
             self.consts
-                .insert(name.clone(), ValueObj::Type(TypeObj::Generated(gen)));
+                .insert(name.clone(), ValueObj::Type(TypeObj::Generated(generator)));
             self.register_methods(&t, &ctx);
             self.patches.insert(name.clone(), ctx);
             Ok(())
@@ -3267,15 +3265,14 @@ impl Context {
             }
             ast::Expr::Set(ast::Set::Comprehension(comp)) => {
                 let mut res = false;
-                for (_, gen) in comp.generators.iter() {
-                    if self.inc_ref_expr(gen, namespace, tmp_tv_cache) {
+                for (_, generator) in comp.generators.iter() {
+                    if self.inc_ref_expr(generator, namespace, tmp_tv_cache) {
                         res = true;
                     }
                 }
-                if let Some(guard) = &comp.guard {
-                    if self.inc_ref_expr(guard, namespace, tmp_tv_cache) {
+                if let Some(guard) = &comp.guard
+                    && self.inc_ref_expr(guard, namespace, tmp_tv_cache) {
                         res = true;
-                    }
                     }
                 res
             }
@@ -3293,8 +3290,8 @@ impl Context {
             }
             ast::Expr::Dict(ast::Dict::Comprehension(comp)) => {
                 let mut res = false;
-                for (_, gen) in comp.generators.iter() {
-                    if self.inc_ref_expr(gen, namespace, tmp_tv_cache) {
+                for (_, generator) in comp.generators.iter() {
+                    if self.inc_ref_expr(generator, namespace, tmp_tv_cache) {
                         res = true;
                     }
                 }

--- a/crates/erg_compiler/context/register.rs
+++ b/crates/erg_compiler/context/register.rs
@@ -406,14 +406,13 @@ impl Context {
             if let Err(es) = self.sub_unify(spec_t, &self_t, name, Some(name.inspect())) {
                 errs.extend(es);
             }
-            if let Some(sig_t) = sig_t {
-                if sig_t.return_t.has_no_unbound_var() && !sig_t.return_t.contains_type(spec_t) {
+            if let Some(sig_t) = sig_t
+                && sig_t.return_t.has_no_unbound_var() && !sig_t.return_t.contains_type(spec_t) {
                     // spec_t == self_t
                     if let Err(es) = self.sub_unify(&self_t, spec_t, name, Some(name.inspect())) {
                         errs.extend(es);
                     }
                 }
-            }
         } else {
             log!(err "self_t is None");
         }
@@ -745,13 +744,12 @@ impl Context {
                     errs.extend(es);
                 }
             }
-            if let Some(var_params) = &mut params.var_params {
-                if let Err(es) =
+            if let Some(var_params) = &mut params.var_params
+                && let Err(es) =
                     self.assign_param(var_params, None, None, tmp_tv_cache, ParamKind::VarParams)
                 {
                     errs.extend(es);
                 }
-            }
             for default in params.defaults.iter_mut() {
                 if let Err(es) = self.assign_param(
                     &mut default.sig,
@@ -763,8 +761,8 @@ impl Context {
                     errs.extend(es);
                 }
             }
-            if let Some(kw_var_params) = &mut params.kw_var_params {
-                if let Err(es) = self.assign_param(
+            if let Some(kw_var_params) = &mut params.kw_var_params
+                && let Err(es) = self.assign_param(
                     kw_var_params,
                     None,
                     None,
@@ -773,7 +771,7 @@ impl Context {
                 ) {
                     errs.extend(es);
                 }
-            }
+        }
         }
         if errs.is_empty() {
             Ok(())
@@ -1280,11 +1278,10 @@ impl Context {
                     if let Err(errs) = self.register_def(def) {
                         total_errs.extend(errs);
                     }
-                    if def.def_kind().is_import() {
-                        if let Err(errs) = self.pre_import(def) {
+                    if def.def_kind().is_import()
+                        && let Err(errs) = self.pre_import(def) {
                             total_errs.extend(errs);
                         }
-                    }
                 }
                 ast::Expr::ClassDef(class_def) => {
                     if let Err(errs) = self.register_def(&class_def.def) {
@@ -1303,12 +1300,11 @@ impl Context {
                                 }
                             };
                         // assume the class has implemented the trait, regardless of whether the implementation is correct
-                        if let Some((trait_, trait_loc)) = &impl_trait {
-                            if let Err(errs) = self.register_trait_impl(&class, trait_, *trait_loc)
+                        if let Some((trait_, trait_loc)) = &impl_trait
+                            && let Err(errs) = self.register_trait_impl(&class, trait_, *trait_loc)
                             {
                                 total_errs.extend(errs);
                             }
-                        }
                         let kind =
                             ContextKind::MethodDefs(impl_trait.as_ref().map(|(t, _)| t.clone()));
                         self.grow(&class.local_name(), kind, vis.clone(), None);
@@ -1320,13 +1316,12 @@ impl Context {
                                     }
                                 }
                                 ClassAttr::Decl(decl) => {
-                                    if let Some(ident) = decl.expr.as_ident() {
-                                        if let Err((_, errs)) =
+                                    if let Some(ident) = decl.expr.as_ident()
+                                        && let Err((_, errs)) =
                                             self.declare_var(ident, &decl.t_spec)
                                         {
                                             total_errs.extend(errs);
                                         }
-                                    }
                                 }
                                 _ => {}
                             }
@@ -1360,11 +1355,10 @@ impl Context {
                     if !self.kind.is_module() {
                         continue;
                     }
-                    if let Some(ident) = tasc.expr.as_ident() {
-                        if let Err((_, errs)) = self.declare_var(ident, &tasc.t_spec) {
+                    if let Some(ident) = tasc.expr.as_ident()
+                        && let Err((_, errs)) = self.declare_var(ident, &tasc.t_spec) {
                             total_errs.extend(errs);
                         }
-                    }
                 }
                 ast::Expr::Call(call) if PYTHON_MODE => {
                     if let Err(errs) = self.register_control_defs(call) {
@@ -1615,13 +1609,12 @@ impl Context {
                         }
                     }
                     self.pop();
-                    if let Some(ident) = sig.ident() {
-                        if let Err(es) =
+                    if let Some(ident) = sig.ident()
+                        && let Err(es) =
                             self.register_gen_const(ident, obj, call, def.def_kind().is_other())
                         {
                             errs.extend(es);
                         }
-                    }
                 } else if let Err((_, es)) = self.pre_define_var(sig, id) {
                     errs.extend(es);
                 }
@@ -2158,7 +2151,7 @@ impl Context {
                                 if let Err(es) = self.register_instance_attrs(&mut ctx, rec, call) {
                                     errs.extend(es);
                                 }
-                            }
+                                }
                             let param_t = if let Some(Type::Record(rec)) = param_t {
                                 let mut rec = rec.clone();
                                 rec.remove_entries(&invalid_fields);
@@ -2277,7 +2270,7 @@ impl Context {
                 }
                 if errs.is_empty() {
                     Ok(())
-                } else {
+            } else {
                     Err(errs)
                 }
             } else {
@@ -2333,9 +2326,9 @@ impl Context {
                 })
                 .unwrap_or_default();
             let varname = VarName::from_str(field.symbol.clone());
-            if let Some(sup_ctx) = sup_ctx {
-                if let Some(sup_vi) = sup_ctx.decls.get(&varname) {
-                    if !self.subtype_of(sub_t, &sup_vi.t) {
+            if let Some(sup_ctx) = sup_ctx
+                && let Some(sup_vi) = sup_ctx.decls.get(&varname)
+                    && !self.subtype_of(sub_t, &sup_vi.t) {
                         invalid_fields.insert(field.clone());
                         errs.push(CompileError::type_mismatch_error(
                             self.cfg.input.clone(),
@@ -2350,8 +2343,6 @@ impl Context {
                             None,
                         ));
                     }
-                }
-            }
         }
         if errs.is_empty() {
             Ok(())
@@ -2758,8 +2749,8 @@ impl Context {
         } else {
             path.parent()
         };
-        if let Some(parent) = parent {
-            if DirKind::from(parent).is_erg_module() {
+        if let Some(parent) = parent
+            && DirKind::from(parent).is_erg_module() {
                 let parent = parent.join("__init__.er");
                 let parent_module = if let Some(parent) = self.get_mod_with_path(&parent) {
                     Some(parent)
@@ -2793,7 +2784,6 @@ impl Context {
                     }
                 }
             }
-        }
         Ok(())
     }
 
@@ -2901,15 +2891,14 @@ impl Context {
                     return Some(*guard.to.clone());
                 }
                 // { r.x in Int } =>  { r in Structural { .x = Int } }
-                else if let ast::Expr::Accessor(ast::Accessor::Attr(attr)) = target {
-                    if attr.obj.as_ref() == expr {
+                else if let ast::Expr::Accessor(ast::Accessor::Attr(attr)) = target
+                    && attr.obj.as_ref() == expr {
                         let mut rec = Dict::new();
                         let vis = self.instantiate_vis_modifier(&attr.ident.vis).ok()?;
                         let field = Field::new(vis, attr.ident.inspect().clone());
                         rec.insert(field, *guard.to.clone());
                         return Some(Type::Record(rec).structuralize());
                     }
-                }
             }
         }
         None
@@ -3159,27 +3148,23 @@ impl Context {
     ) -> bool {
         let mut res = false;
         for param in params.non_defaults.iter() {
-            if let Some(expr) = param.t_spec.as_ref().map(|ts| &ts.t_spec_as_expr) {
-                if self.inc_ref_expr(expr, namespace, tmp_tv_cache) {
+            if let Some(expr) = param.t_spec.as_ref().map(|ts| &ts.t_spec_as_expr)
+                && self.inc_ref_expr(expr, namespace, tmp_tv_cache) {
                     res = true;
                 }
-            }
         }
         if let Some(expr) = params
             .var_params
             .as_ref()
             .and_then(|p| p.t_spec.as_ref().map(|ts| &ts.t_spec_as_expr))
-        {
-            if self.inc_ref_expr(expr, namespace, tmp_tv_cache) {
+            && self.inc_ref_expr(expr, namespace, tmp_tv_cache) {
                 res = true;
             }
-        }
         for param in params.defaults.iter() {
-            if let Some(expr) = param.sig.t_spec.as_ref().map(|ts| &ts.t_spec_as_expr) {
-                if self.inc_ref_expr(expr, namespace, tmp_tv_cache) {
+            if let Some(expr) = param.sig.t_spec.as_ref().map(|ts| &ts.t_spec_as_expr)
+                && self.inc_ref_expr(expr, namespace, tmp_tv_cache) {
                     res = true;
                 }
-            }
             if self.inc_ref_expr(&param.default_val, namespace, tmp_tv_cache) {
                 res = true;
             }
@@ -3188,11 +3173,9 @@ impl Context {
             .kw_var_params
             .as_ref()
             .and_then(|p| p.t_spec.as_ref().map(|ts| &ts.t_spec_as_expr))
-        {
-            if self.inc_ref_expr(expr, namespace, tmp_tv_cache) {
+            && self.inc_ref_expr(expr, namespace, tmp_tv_cache) {
                 res = true;
             }
-        }
         res
     }
 
@@ -3217,11 +3200,10 @@ impl Context {
                         res = true;
                     }
                 }
-                if let Some(arg) = call.args.var_args() {
-                    if self.inc_ref_expr(&arg.expr, namespace, tmp_tv_cache) {
+                if let Some(arg) = call.args.var_args()
+                    && self.inc_ref_expr(&arg.expr, namespace, tmp_tv_cache) {
                         res = true;
                     }
-                }
                 for arg in call.args.kw_args() {
                     if self.inc_ref_expr(&arg.expr, namespace, tmp_tv_cache) {
                         res = true;
@@ -3294,7 +3276,7 @@ impl Context {
                     if self.inc_ref_expr(guard, namespace, tmp_tv_cache) {
                         res = true;
                     }
-                }
+                    }
                 res
             }
             ast::Expr::Dict(ast::Dict::Normal(dict)) => {
@@ -3316,11 +3298,10 @@ impl Context {
                         res = true;
                     }
                 }
-                if let Some(guard) = &comp.guard {
-                    if self.inc_ref_expr(guard, namespace, tmp_tv_cache) {
+                if let Some(guard) = &comp.guard
+                    && self.inc_ref_expr(guard, namespace, tmp_tv_cache) {
                         res = true;
                     }
-                }
                 res
             }
             ast::Expr::TypeAscription(ascription) => {

--- a/crates/erg_compiler/context/register.rs
+++ b/crates/erg_compiler/context/register.rs
@@ -11,7 +11,7 @@ use erg_common::python_util::BUILTIN_PYTHON_MODS;
 use erg_common::set::Set;
 use erg_common::traits::{Locational, Stream, StructuralEq};
 use erg_common::triple::Triple;
-use erg_common::{get_hash, log, set, unique_in_place, Str};
+use erg_common::{Str, get_hash, log, set, unique_in_place};
 
 use ast::{
     ConstIdentifier, Decorator, DefId, Identifier, OperationKind, PolyTypeSpec, PreDeclTypeSpec,
@@ -31,10 +31,10 @@ use crate::ty::{
 };
 
 use crate::context::{ClassDefType, Context, ContextKind, DefaultInfo, RegistrationMode};
-use crate::error::{concat_result, readable_name, Failable};
 use crate::error::{
     CompileError, CompileErrors, CompileResult, TyCheckError, TyCheckErrors, TyCheckResult,
 };
+use crate::error::{Failable, concat_result, readable_name};
 use crate::hir::Literal;
 use crate::varinfo::{AbsLocation, AliasInfo, Mutability, VarInfo, VarKind};
 use crate::{feature_error, hir, unreachable_error};
@@ -266,11 +266,7 @@ impl Context {
             )))
         } else {
             self.decls.insert(sig.ident.name.clone(), vi);
-            if errs.is_empty() {
-                Ok(())
-            } else {
-                Err(errs)
-            }
+            if errs.is_empty() { Ok(()) } else { Err(errs) }
         }
     }
 
@@ -464,11 +460,7 @@ impl Context {
                 );
                 sig.vi = vi.clone();
                 self.params.push((Some(VarName::from_static("_")), vi));
-                if errs.is_empty() {
-                    Ok(())
-                } else {
-                    Err(errs)
-                }
+                if errs.is_empty() { Ok(()) } else { Err(errs) }
             }
             ast::ParamPattern::VarName(name) => {
                 if self
@@ -520,11 +512,7 @@ impl Context {
                     self.index().register(name.inspect().clone(), &vi);
                     sig.vi = vi.clone();
                     self.params.push((Some(name.clone()), vi));
-                    if errs.is_empty() {
-                        Ok(())
-                    } else {
-                        Err(errs)
-                    }
+                    if errs.is_empty() { Ok(()) } else { Err(errs) }
                 }
             }
             ast::ParamPattern::Ref(name) => {
@@ -573,11 +561,7 @@ impl Context {
                     );
                     sig.vi = vi.clone();
                     self.params.push((Some(name.clone()), vi));
-                    if errs.is_empty() {
-                        Ok(())
-                    } else {
-                        Err(errs)
-                    }
+                    if errs.is_empty() { Ok(()) } else { Err(errs) }
                 }
             }
             ast::ParamPattern::RefMut(name) => {
@@ -626,11 +610,7 @@ impl Context {
                     );
                     sig.vi = vi.clone();
                     self.params.push((Some(name.clone()), vi));
-                    if errs.is_empty() {
-                        Ok(())
-                    } else {
-                        Err(errs)
-                    }
+                    if errs.is_empty() { Ok(()) } else { Err(errs) }
                 }
             }
             other => {
@@ -772,12 +752,7 @@ impl Context {
                     errs.extend(es);
                 }
         }
-        }
-        if errs.is_empty() {
-            Ok(())
-        } else {
-            Err(errs)
-        }
+        if errs.is_empty() { Ok(()) } else { Err(errs) }
     }
 
     fn unify_params_t(
@@ -858,11 +833,7 @@ impl Context {
             );
             errs.extend(es);
         }
-        if errs.is_empty() {
-            Ok(())
-        } else {
-            Err(errs)
-        }
+        if errs.is_empty() { Ok(()) } else { Err(errs) }
     }
 
     /// ## Errors
@@ -1067,7 +1038,7 @@ impl Context {
                                         ),
                                         None,
                                     )),
-                                ))
+                                ));
                             }
                         };
                         let class = match self.instantiate_typespec_full(
@@ -1620,11 +1591,7 @@ impl Context {
                 }
             }
         }
-        if errs.is_empty() {
-            Ok(())
-        } else {
-            Err(errs)
-        }
+        if errs.is_empty() { Ok(()) } else { Err(errs) }
     }
 
     /// e.g. .new
@@ -2398,11 +2365,7 @@ impl Context {
                 ));
             }
         }
-        if errs.is_empty() {
-            Ok(())
-        } else {
-            Err(errs)
-        }
+        if errs.is_empty() { Ok(()) } else { Err(errs) }
     }
 
     fn gen_class_new_method(

--- a/crates/erg_compiler/context/unify.rs
+++ b/crates/erg_compiler/context/unify.rs
@@ -77,11 +77,10 @@ impl<L: Locational> Unifier<'_, '_, '_, L> {
             if &sup == maybe_super {
                 return Ok(());
             }
-        } else if let Some(sub) = maybe_super.get_sub() {
-            if &sub == maybe_sub {
+        } else if let Some(sub) = maybe_super.get_sub()
+            && &sub == maybe_sub {
                 return Ok(());
             }
-        }
         match (maybe_sub, maybe_super) {
             (FreeVar(fv), _) if fv.is_linked() => self.occur(&fv.unwrap_linked(), maybe_super),
             (_, FreeVar(fv)) if fv.is_linked() => self.occur(maybe_sub, &fv.unwrap_linked()),
@@ -120,11 +119,10 @@ impl<L: Locational> Unifier<'_, '_, '_, L> {
                 {
                     self.occur(lhs, rhs)?;
                 }
-                if let Some(lhs) = lhs.var_params.as_ref() {
-                    if let Some(rhs) = rhs.var_params.as_ref() {
+                if let Some(lhs) = lhs.var_params.as_ref()
+                    && let Some(rhs) = rhs.var_params.as_ref() {
                         self.occur(lhs.typ(), rhs.typ())?;
                     }
-                }
                 for (lhs, rhs) in lhs
                     .non_default_params
                     .iter()
@@ -291,11 +289,10 @@ impl<L: Locational> Unifier<'_, '_, '_, L> {
                 {
                     self.occur_inner(lhs, rhs)?;
                 }
-                if let Some(lhs) = lhs.var_params.as_ref() {
-                    if let Some(rhs) = rhs.var_params.as_ref() {
+                if let Some(lhs) = lhs.var_params.as_ref()
+                    && let Some(rhs) = rhs.var_params.as_ref() {
                         self.occur_inner(lhs.typ(), rhs.typ())?;
                     }
-                }
                 for (lhs, rhs) in lhs
                     .non_default_params
                     .iter()
@@ -983,11 +980,9 @@ impl<L: Locational> Unifier<'_, '_, '_, L> {
             | (Predicate::Value(ValueObj::Bool(b)), call @ Predicate::Call { .. }) => {
                 if let Ok(Predicate::Value(ValueObj::Bool(evaled))) =
                     self.ctx.eval_pred(call.clone())
-                {
-                    if &evaled == b {
+                    && &evaled == b {
                         return Ok(());
                     }
-                }
                 Err(TyCheckErrors::from(TyCheckError::pred_unification_error(
                     self.ctx.cfg.input.clone(),
                     line!() as usize,
@@ -1406,11 +1401,10 @@ impl<L: Locational> Unifier<'_, '_, '_, L> {
                 // * sub_unify(Bool,  ?T(<: Bool or Y)): (?T == Bool)
                 // * sub_unify(Float, ?T(<: Structural{ .imag = ?U })) ==> ?U == Float
                 // * sub_unify(K(Int, 1), ?T(:> K(?A, ?N))) ==> ?A(:> Int), ?N == 1
-                if let Type::Refinement(refine) = maybe_sub {
-                    if refine.t.addr_eq(maybe_super) {
+                if let Type::Refinement(refine) = maybe_sub
+                    && refine.t.addr_eq(maybe_super) {
                         return Ok(());
                     }
-                }
                 if let Some((sub, mut supe)) = super_fv.get_subsup() {
                     if !supe.is_recursive() {
                         self.sub_unify(maybe_sub, &supe)?;
@@ -1885,11 +1879,9 @@ impl<L: Locational> Unifier<'_, '_, '_, L> {
                     .eval_proj_call(*lhs.clone(), attr_name.clone(), args.clone(), self.loc)
                     .ok()
                     .and_then(|tp| self.ctx.convert_tp_into_type(tp).ok())
-                {
-                    if maybe_super != &evaled {
+                    && maybe_super != &evaled {
                         self.sub_unify(maybe_sub, &evaled)?;
                     }
-                }
             }
             (
                 ProjCall {
@@ -1904,11 +1896,9 @@ impl<L: Locational> Unifier<'_, '_, '_, L> {
                     .eval_proj_call(*lhs.clone(), attr_name.clone(), args.clone(), self.loc)
                     .ok()
                     .and_then(|tp| self.ctx.convert_tp_into_type(tp).ok())
-                {
-                    if maybe_sub != &evaled {
+                    && maybe_sub != &evaled {
                         self.sub_unify(&evaled, maybe_super)?;
                     }
-                }
             }
             // TODO: Judgment for any number of preds
             (Refinement(sub), Refinement(supe)) => {
@@ -2283,14 +2273,12 @@ impl Context {
             _ => super_self,
         };
         let sub_self = sub_self.derefine();
-        if self.subtype_of(super_self, &sub_self) {
-            if let Some(return_t) = subr.return_t() {
-                if return_t.has_no_unbound_var() && !return_t.contains_type(&sub_self) {
+        if self.subtype_of(super_self, &sub_self)
+            && let Some(return_t) = subr.return_t()
+                && return_t.has_no_unbound_var() && !return_t.contains_type(&sub_self) {
                     // callee.ref_t() == self_t
                     let _ = unifier.sub_unify(super_self, &sub_self);
                 }
-            }
-        }
         Ok(())
     }
 

--- a/crates/erg_compiler/declare.rs
+++ b/crates/erg_compiler/declare.rs
@@ -105,16 +105,14 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
         };
         // Typ = 'typ': ClassType
         // => 'typ': {<type Typ>}
-        if let hir::Expr::TypeAsc(hir::TypeAscription { expr, .. }) = &chunk {
-            if let hir::Expr::Accessor(acc) = expr.as_ref() {
-                if let Some(name) = acc.local_name() {
+        if let hir::Expr::TypeAsc(hir::TypeAscription { expr, .. }) = &chunk
+            && let hir::Expr::Accessor(acc) = expr.as_ref()
+                && let Some(name) = acc.local_name() {
                     let name = VarName::from_str(Str::rc(name));
                     if let Some(vi) = self.module.context.get_mut_current_scope_var(&name) {
                         vi.t = t.clone();
                     }
                 }
-            }
-        }
         ident.vi.t = t;
         ident.vi.py_name = py_name;
         ident.vi.def_loc = self.module.context.absolutize(ident.raw.name.loc());

--- a/crates/erg_compiler/declare.rs
+++ b/crates/erg_compiler/declare.rs
@@ -1009,10 +1009,10 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
             None,
             Some(py_name),
         )?;
-        if let Some(gen) = ty_obj {
+        if let Some(generator) = ty_obj {
             self.module
                 .context
-                .register_gen_type(&new_ident, gen, None)?;
+                .register_gen_type(&new_ident, generator, None)?;
         }
         Ok(())
     }

--- a/crates/erg_compiler/declare.rs
+++ b/crates/erg_compiler/declare.rs
@@ -4,9 +4,9 @@ use erg_common::consts::PYTHON_MODE;
 use erg_common::error::Location;
 use erg_common::pathutil::NormalizedPathBuf;
 use erg_common::traits::{Locational, Runnable, Stream};
-use erg_common::{fn_name, log, set, Str, Triple};
+use erg_common::{Str, Triple, fn_name, log, set};
 
-use erg_parser::ast::{self, AscriptionKind, DefId, Identifier, TypeAppArgsKind, VarName, AST};
+use erg_parser::ast::{self, AST, AscriptionKind, DefId, Identifier, TypeAppArgsKind, VarName};
 use erg_parser::build_ast::ASTBuildable;
 use erg_parser::desugar::Desugarer;
 

--- a/crates/erg_compiler/effectcheck.rs
+++ b/crates/erg_compiler/effectcheck.rs
@@ -232,8 +232,8 @@ impl<'c> SideEffectChecker<'c> {
                 ));
             }
         }
-        if let Some(var_arg) = params.var_params.as_deref() {
-            if var_arg.vi.t.is_procedure() && !var_arg.inspect().unwrap().ends_with('!') {
+        if let Some(var_arg) = params.var_params.as_deref()
+            && var_arg.vi.t.is_procedure() && !var_arg.inspect().unwrap().ends_with('!') {
                 self.errs.push(EffectError::proc_assign_error(
                     self.cfg.input.clone(),
                     line!() as usize,
@@ -241,7 +241,6 @@ impl<'c> SideEffectChecker<'c> {
                     self.full_path(),
                 ));
             }
-        }
         for d_param in params.defaults.iter() {
             if d_param.sig.vi.t.is_procedure() && !d_param.inspect().unwrap().ends_with('!') {
                 self.errs.push(EffectError::proc_assign_error(
@@ -500,10 +499,9 @@ impl<'c> SideEffectChecker<'c> {
             && call
                 .signature_t()
                 .is_some_and(|sig| sig.param_ts().iter().all(|p| !p.contains_type(gen_t)))
-        {
-            if let Some(typ_ctx) = self.ctx.get_nominal_type_ctx(gen_t) {
-                if typ_ctx.get_method_kv("__init__!").is_some()
-                    || typ_ctx.get_method_kv("__del__!").is_some()
+            && let Some(typ_ctx) = self.ctx.get_nominal_type_ctx(gen_t)
+                && (typ_ctx.get_method_kv("__init__!").is_some()
+                    || typ_ctx.get_method_kv("__del__!").is_some())
                 {
                     self.errs.push(EffectError::constructor_destructor_error(
                         self.cfg.input.clone(),
@@ -512,8 +510,6 @@ impl<'c> SideEffectChecker<'c> {
                         self.full_path(),
                     ));
                 }
-            }
-        }
     }
 
     pub(crate) fn is_impure(expr: &Expr) -> bool {

--- a/crates/erg_compiler/hir.rs
+++ b/crates/erg_compiler/hir.rs
@@ -1710,11 +1710,10 @@ impl Block {
     pub fn remove_def(&mut self, name: &str) -> Option<Def> {
         let mut i = 0;
         while i < self.0.len() {
-            if let Expr::Def(def) = &self.0[i] {
-                if def.sig.ident().inspect() == name {
+            if let Expr::Def(def) = &self.0[i]
+                && def.sig.ident().inspect() == name {
                     return Def::try_from(self.0.remove(i)).ok();
                 }
-            }
             i += 1;
         }
         None

--- a/crates/erg_compiler/lint.rs
+++ b/crates/erg_compiler/lint.rs
@@ -149,11 +149,10 @@ impl<ASTBuilder: ASTBuildable> GenericASTLowerer<ASTBuilder> {
                         warns.extend(ws);
                     }
                 }
-                if let Some(var_args) = &call.args.var_args {
-                    if let Err(ws) = self.block_use_check(&var_args.expr) {
+                if let Some(var_args) = &call.args.var_args
+                    && let Err(ws) = self.block_use_check(&var_args.expr) {
                         warns.extend(ws);
                     }
-                }
                 for arg in call.args.kw_args.iter() {
                     if let Err(ws) = self.block_use_check(&arg.expr) {
                         warns.extend(ws);

--- a/crates/erg_compiler/lower.rs
+++ b/crates/erg_compiler/lower.rs
@@ -332,11 +332,10 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
                 self.module.context.caused_by(),
             )
         })?;
-        if let Some(expect) = expect {
-            if let Err(_errs) = self.module.context.sub_unify(&lit.t(), expect, &loc, None) {
+        if let Some(expect) = expect
+            && let Err(_errs) = self.module.context.sub_unify(&lit.t(), expect, &loc, None) {
                 // self.errs.extend(errs);
             }
-        }
         Ok(lit)
     }
 
@@ -616,11 +615,10 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
             .context
             .grow("<record>", ContextKind::Dummy, Private, None);
         for attr in record.attrs.iter() {
-            if attr.sig.is_const() {
-                if let Err(es) = self.module.context.register_def(attr) {
+            if attr.sig.is_const()
+                && let Err(es) = self.module.context.register_def(attr) {
                     errs.extend(es);
                 }
-            }
         }
         for attr in record.attrs.into_iter() {
             let expect =
@@ -1010,15 +1008,14 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
                         VarInfo::ILLEGAL
                     }
                 };
-                if let Some(expect) = expect {
-                    if let Err(_errs) =
+                if let Some(expect) = expect
+                    && let Err(_errs) =
                         self.module
                             .context
                             .sub_unify(&vi.t, expect, &attr.ident.loc(), None)
                     {
                         // self.errs.extend(errs);
                     }
-                }
                 let ident = hir::Identifier::new(attr.ident, None, vi);
                 let acc = hir::Accessor::Attr(hir::Attribute::new(obj, ident));
                 // debug_assert!(acc.ref_t().has_no_qvar(), "{acc} has qvar");
@@ -1104,15 +1101,14 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
             )
         };
         self.inc_ref(ident.inspect(), &vi, &ident.name);
-        if let Some(expect) = expect {
-            if let Err(_errs) = self
+        if let Some(expect) = expect
+            && let Err(_errs) = self
                 .module
                 .context
                 .sub_unify(&vi.t, expect, &ident.loc(), None)
             {
                 // self.errs.extend(errs);
             }
-        }
         let ident = hir::Identifier::new(ident, __name__, vi);
         if !ident.vi.is_toplevel()
             && ident.vi.def_namespace() != &self.module.context.name
@@ -1335,15 +1331,14 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
                 *return_t = guard;
             }
         }
-        if let Some(expect) = expect {
-            if let Err(_errs) =
+        if let Some(expect) = expect
+            && let Err(_errs) =
                 self.module
                     .context
                     .sub_unify(vi.t.return_t().unwrap(), expect, &args, None)
             {
                 // self.errs.extend(errs);
             }
-        }
         let mut args = args.into_iter();
         let lhs = args.next().unwrap().expr;
         let rhs = args.next().unwrap().expr;
@@ -1378,15 +1373,14 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
                 errors.extend(errs);
                 VarInfo::ILLEGAL
             });
-        if let Some(expect) = expect {
-            if let Err(_errs) =
+        if let Some(expect) = expect
+            && let Err(_errs) =
                 self.module
                     .context
                     .sub_unify(vi.t.return_t().unwrap(), expect, &args, None)
             {
                 // self.errs.extend(errs);
             }
-        }
         let mut args = args.into_iter();
         let expr = args.next().unwrap().expr;
         let unary = hir::UnaryOp::new(unary.op, expr, vi);
@@ -1575,15 +1569,13 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
             .and_then(|vi| <&SubrType>::try_from(&vi.t).ok());
         if let Some((subr_return_t, expect)) =
             expect_subr.map(|subr| subr.return_t.as_ref()).zip(expect)
-        {
-            if let Err(_errs) = self
+            && let Err(_errs) = self
                 .module
                 .context
                 .sub_unify(subr_return_t, expect, &(), None)
             {
                 // self.errs.extend(errs);
             }
-        }
         let mut hir_args = self.lower_args(call.args, expect_subr, &mut errs);
         let mut vi = match self.module.context.get_call_t(
             &obj,
@@ -1622,11 +1614,10 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
             Some(hir::Identifier::new(attr_name, None, vi))
         } else {
             if let hir::Expr::Call(call) = &obj {
-                if call.return_t().is_some() {
-                    if let Some(ref_mut_t) = obj.ref_mut_t() {
+                if call.return_t().is_some()
+                    && let Some(ref_mut_t) = obj.ref_mut_t() {
                         *ref_mut_t = vi.t;
                     }
-                }
             } else if let Some(ref_mut_t) = obj.ref_mut_t() {
                 *ref_mut_t = vi.t;
             }
@@ -1637,19 +1628,16 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
             .signature_t()
             .and_then(|sig| sig.return_t())
             .zip(expect)
-        {
-            if let Err(_errs) = self.module.context.sub_unify(found, expect, &call, None) {
+            && let Err(_errs) = self.module.context.sub_unify(found, expect, &call, None) {
                 // self.errs.extend(errs);
             }
-        }
         if pushed {
             self.module.context.higher_order_caller.pop();
         }
-        if errs.is_empty() {
-            if let Err(es) = self.exec_additional_op(&mut call) {
+        if errs.is_empty()
+            && let Err(es) = self.exec_additional_op(&mut call) {
                 errs.extend(es);
             }
-        }
         if errs.is_empty() {
             Ok(call)
         } else {
@@ -1863,8 +1851,8 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
                             continue;
                         }
                     };
-                    if let Some(expect) = expect.and_then(|subr| subr.default_params.get(n)) {
-                        if !self
+                    if let Some(expect) = expect.and_then(|subr| subr.default_params.get(n))
+                        && !self
                             .module
                             .context
                             .subtype_of(default_val.ref_t(), expect.typ())
@@ -1883,7 +1871,6 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
                             );
                             errs.push(err);
                         }
-                    }
                     hir_defaults.push(hir::DefaultParamSignature::new(sig, default_val));
                 }
                 Err((_default, es)) => errs.extend(es),
@@ -2312,8 +2299,8 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
                 if let Some(expect_body_t) = expect_body_t {
                     // TODO: expect_body_t is smaller for constants
                     // TODO: 定数の場合、expect_body_tのほうが小さくなってしまう
-                    if !sig.is_const() {
-                        if let Err(e) = self.var_result_t_check(
+                    if !sig.is_const()
+                        && let Err(e) = self.var_result_t_check(
                             &sig,
                             ident.inspect(),
                             &expect_body_t,
@@ -2322,7 +2309,6 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
                             errors.push(e);
                             no_reassign = true;
                         }
-                    }
                 }
                 let found_body_t = if sig.is_phi() {
                     self.module
@@ -2426,8 +2412,8 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
 
     fn lower_glob(&mut self, token: Token, body: hir::DefBody) -> LowerResult<hir::Def> {
         let names = vec![];
-        if let Some(path) = body.ref_t().module_path() {
-            if let Some(module) = self.module.context.get_mod_with_path(&path) {
+        if let Some(path) = body.ref_t().module_path()
+            && let Some(module) = self.module.context.get_mod_with_path(&path) {
                 for (name, vi) in module.local_dir().cloned() {
                     self.module
                         .context
@@ -2437,7 +2423,6 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
                         .insert(name, vi);
                 }
             }
-        }
         let vis = VisibilityModifier::Public;
         let sig = hir::Signature::Glob(hir::GlobSignature::new(token, vis, names, body.t()));
         Ok(hir::Def::new(sig, body))
@@ -2774,8 +2759,8 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
             for attr in methods.attrs.iter() {
                 match attr {
                     ast::ClassAttr::Def(def) => {
-                        if let Some(ident) = def.sig.ident() {
-                            if self
+                        if let Some(ident) = def.sig.ident()
+                            && self
                                 .module
                                 .context
                                 .get_instance_attr(ident.inspect())
@@ -2790,7 +2775,6 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
                                         ident.inspect(),
                                     ));
                             }
-                        }
                     }
                     ast::ClassAttr::Decl(_) | ast::ClassAttr::Doc(_) => {}
                 }
@@ -2832,11 +2816,9 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
                 .context
                 .get_mut_nominal_type_ctx(&class)
                 .map(|ctx| &mut ctx.methods_list)
-            {
-                if let Some(idx) = methods_idx {
+                && let Some(idx) = methods_idx {
                     methods_list.remove(idx);
                 }
-            }
             if let Err(errs) = self.module.context.check_decls() {
                 errors.extend(errs);
             }
@@ -2880,11 +2862,10 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
                 Some(hir::Expr::Call(call)) => Some(call),
                 _ => None,
             };
-            if let Some(sup_type) = call.and_then(|call| call.args.get_left_or_key("Super")) {
-                if let Err(err) = self.check_inheritable(&type_obj, sup_type, &sig) {
+            if let Some(sup_type) = call.and_then(|call| call.args.get_left_or_key("Super"))
+                && let Err(err) = self.check_inheritable(&type_obj, sup_type, &sig) {
                     errors.extend(err);
                 }
-            }
         }
         let constructor = class_ctx
             .and_then(|ctx| {
@@ -3058,12 +3039,13 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
     }
 
     fn widen_type(&mut self, attr: &mut hir::Accessor, expr: &hir::Expr) -> bool {
-        for sup in self
+        let supers: Vec<_> = self
             .module
             .context
             .get_super_classes_or_self(attr.ref_t())
             .skip(1)
-        {
+            .collect();
+        for sup in supers {
             if sup == Type::Obj {
                 break;
             }
@@ -3074,15 +3056,14 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
                 if let Some(attr_t) = attr.ref_mut_t() {
                     *attr_t = sup.clone();
                 }
-                if let Some(ident) = attr.as_ident() {
-                    if let Some(vi) = self
+                if let Some(ident) = attr.as_ident()
+                    && let Some(vi) = self
                         .module
                         .context
                         .rec_get_mut_var_info(&ident.raw, AccessKind::Name)
                     {
                         vi.t = sup;
                     }
-                }
                 return true;
             }
         }
@@ -3095,8 +3076,8 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
         sup_class: &hir::Expr,
         sub_sig: &hir::Signature,
     ) -> LowerResult<()> {
-        if let Some(TypeObj::Generated(gen)) = type_obj.base_or_sup() {
-            if let Some(ctx) = self.module.context.get_nominal_type_ctx(gen.typ()) {
+        if let Some(TypeObj::Generated(gen_type)) = type_obj.base_or_sup() {
+            if let Some(ctx) = self.module.context.get_nominal_type_ctx(gen_type.typ()) {
                 for super_trait in ctx.super_traits.iter() {
                     if self
                         .module
@@ -3107,11 +3088,10 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
                     }
                 }
             }
-            if let Some(impls) = gen.impls() {
-                if impls.contains_intersec(&mono("InheritableType")) {
+            if let Some(impls) = gen_type.impls()
+                && impls.contains_intersec(&mono("InheritableType")) {
                     return Ok(());
                 }
-            }
             return Err(LowerError::inheritance_error(
                 self.cfg.input.clone(),
                 line!() as usize,
@@ -3137,11 +3117,10 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
                 ) {
                     if let Some(sup_vi) = sup.get_current_scope_var(method_name) {
                         // must `@Override`
-                        if let Some(decos) = &vi.comptime_decos {
-                            if decos.contains("Override") {
+                        if let Some(decos) = &vi.comptime_decos
+                            && decos.contains("Override") {
                                 continue;
                             }
-                        }
                         if sup_vi.impl_of() != impl_trait {
                             continue;
                         }
@@ -3694,13 +3673,11 @@ impl<A: ASTBuildable> GenericASTLowerer<A> {
             // e.g. casted == {x: Obj | x != None}, expr: Int or NoneType => intersec == Int
             let intersec = self.module.context.intersection(expr.ref_t(), &casted);
             // bad narrowing: C and Structural { foo = Foo }
-            if expr.ref_t().is_proj()
-                || (intersec != Type::Never && intersec.ands().iter().all(|t| !t.is_structural()))
-            {
-                if let Some(ref_mut_t) = expr.ref_mut_t() {
+            if (expr.ref_t().is_proj()
+                || (intersec != Type::Never && intersec.ands().iter().all(|t| !t.is_structural())))
+                && let Some(ref_mut_t) = expr.ref_mut_t() {
                     *ref_mut_t = intersec;
                 }
-            }
         }
         // debug_assert!(expr.ref_t().has_no_qvar(), "{expr} has qvar");
         Ok(expr)

--- a/crates/erg_compiler/ownercheck.rs
+++ b/crates/erg_compiler/ownercheck.rs
@@ -115,21 +115,19 @@ impl OwnershipChecker {
                             self.define_param(name);
                         }
                     }
-                    if let Some(var) = var_params {
-                        if let ParamPattern::VarName(name) = &var.raw.pat {
+                    if let Some(var) = var_params
+                        && let ParamPattern::VarName(name) = &var.raw.pat {
                             self.define_param(name);
                         }
-                    }
                     for param in d_params {
                         if let ParamPattern::VarName(name) = &param.sig.raw.pat {
                             self.define_param(name);
                         }
                     }
-                    if let Some(kw_var) = kw_var {
-                        if let ParamPattern::VarName(name) = &kw_var.raw.pat {
+                    if let Some(kw_var) = kw_var
+                        && let ParamPattern::VarName(name) = &kw_var.raw.pat {
                             self.define_param(name);
                         }
-                    }
                 }
                 self.check_block(&def.body.block);
                 self.path_stack.pop();

--- a/crates/erg_compiler/transpile.rs
+++ b/crates/erg_compiler/transpile.rs
@@ -369,8 +369,8 @@ impl Transpiler {
     fn lower(&mut self, hir: HIR) -> CompileResult<TranspiledFile> {
         match self.cfg.transpile_target {
             Some(TranspileTarget::Json) => {
-                let mut gen = JsonGenerator::new(self.cfg.copy());
-                Ok(TranspiledFile::Json(gen.transpile(hir)?))
+                let mut json_gen = JsonGenerator::new(self.cfg.copy());
+                Ok(TranspiledFile::Json(json_gen.transpile(hir)?))
             }
             _ => Ok(TranspiledFile::PyScript(
                 self.script_generator.transpile(hir),

--- a/crates/erg_compiler/ty/const_subr.rs
+++ b/crates/erg_compiler/ty/const_subr.rs
@@ -264,7 +264,7 @@ impl ConstSubr {
         match self {
             ConstSubr::User(user) => &user.sig_t,
             ConstSubr::Builtin(builtin) => &builtin.sig_t,
-            ConstSubr::Gen(gen) => &gen.sig_t,
+            ConstSubr::Gen(generator) => &generator.sig_t,
         }
     }
 
@@ -285,8 +285,8 @@ impl ConstSubr {
                         return None;
                     }
                 };
-                if let Type::Refinement(refine) = subr.return_t.as_ref() {
-                    if let Predicate::Equal { rhs, .. } = refine.pred.as_ref() {
+                if let Type::Refinement(refine) = subr.return_t.as_ref()
+                    && let Predicate::Equal { rhs, .. } = refine.pred.as_ref() {
                         let return_t = ctx.convert_tp_into_type(rhs.clone()).ok()?;
                         let var_params = subr.var_params.as_ref().map(|t| t.as_ref());
                         let kw_var_params = subr.kw_var_params.as_ref().map(|t| t.as_ref());
@@ -304,12 +304,11 @@ impl ConstSubr {
                             subr_t
                         };
                         return Some(subr_t);
-                    }
                 }
                 None
             }
             ConstSubr::Builtin(builtin) => builtin.as_type.clone(),
-            ConstSubr::Gen(gen) => gen.as_type.clone(),
+            ConstSubr::Gen(generator) => generator.as_type.clone(),
         }
     }
 

--- a/crates/erg_compiler/ty/const_subr.rs
+++ b/crates/erg_compiler/ty/const_subr.rs
@@ -1,10 +1,10 @@
 use std::fmt;
 
+use erg_common::Str;
 use erg_common::consts::DEBUG_MODE;
 use erg_common::dict::Dict;
 #[allow(unused_imports)]
 use erg_common::log;
-use erg_common::Str;
 
 use erg_parser::ast::{Block, ConstBlock, Params};
 
@@ -304,7 +304,7 @@ impl ConstSubr {
                             subr_t
                         };
                         return Some(subr_t);
-                }
+                    }
                 None
             }
             ConstSubr::Builtin(builtin) => builtin.as_type.clone(),

--- a/crates/erg_compiler/ty/mod.rs
+++ b/crates/erg_compiler/ty/mod.rs
@@ -966,33 +966,27 @@ impl SubrType {
     pub fn replace_params(mut self, target_and_to: Vec<(Str, Str)>) -> Self {
         for (target, to) in target_and_to {
             for nd in self.non_default_params.iter_mut() {
-                if let Some(name) = nd.name_mut() {
-                    if name == target {
+                if let Some(name) = nd.name_mut()
+                    && name == target {
                         *name = to.clone();
                     }
-                }
             }
-            if let Some(var) = self.var_params.as_mut() {
-                if let Some(name) = var.name_mut() {
-                    if name == target {
+            if let Some(var) = self.var_params.as_mut()
+                && let Some(name) = var.name_mut()
+                    && name == target {
                         *name = to.clone();
                     }
-                }
-            }
             for d in self.default_params.iter_mut() {
-                if let Some(name) = d.name_mut() {
-                    if name == target {
+                if let Some(name) = d.name_mut()
+                    && name == target {
                         *name = to.clone();
                     }
-                }
             }
-            if let Some(kw_var) = self.kw_var_params.as_mut() {
-                if let Some(name) = kw_var.name_mut() {
-                    if name == target {
+            if let Some(kw_var) = self.kw_var_params.as_mut()
+                && let Some(name) = kw_var.name_mut()
+                    && name == target {
                         *name = to.clone();
                     }
-                }
-            }
             *self.return_t = self.return_t.replace_param(&target, &to);
         }
         self
@@ -4556,11 +4550,10 @@ impl Type {
         match self {
             Self::FreeVar(fv) if fv.is_linked() => fv.unwrap_linked().map(f, tvs),
             Self::FreeVar(fv) => {
-                if let Some(id) = fv.unbound_id() {
-                    if let Some(tv) = tvs.get_tv(id) {
+                if let Some(id) = fv.unbound_id()
+                    && let Some(tv) = tvs.get_tv(id) {
                         return tv;
                     }
-                }
                 if let Some((sub, sup)) = fv.get_subsup() {
                     fv.dummy_link();
                     let new_sub = f(sub.clone());
@@ -4669,11 +4662,10 @@ impl Type {
         match self {
             Self::FreeVar(fv) if fv.is_linked() => fv.unwrap_linked()._replace_tp(target, to, tvs),
             Self::FreeVar(fv) => {
-                if let Some(id) = fv.unbound_id() {
-                    if let Some(tv) = tvs.get_tv(id) {
+                if let Some(id) = fv.unbound_id()
+                    && let Some(tv) = tvs.get_tv(id) {
                         return tv;
                     }
-                }
                 if let Some((sub, sup)) = fv.get_subsup() {
                     fv.dummy_link();
                     let new_sub = sub.clone()._replace_tp(target, to, tvs);
@@ -4787,11 +4779,10 @@ impl Type {
         match self {
             Self::FreeVar(fv) if fv.is_linked() => fv.unwrap_linked().map_tp(f, tvs),
             Self::FreeVar(fv) => {
-                if let Some(id) = fv.unbound_id() {
-                    if let Some(tv) = tvs.get_tv(id) {
+                if let Some(id) = fv.unbound_id()
+                    && let Some(tv) = tvs.get_tv(id) {
                         return tv;
                     }
-                }
                 if let Some((sub, sup)) = fv.get_subsup() {
                     fv.dummy_link();
                     let new_sub = sub.clone().map_tp(f, tvs);
@@ -4893,11 +4884,10 @@ impl Type {
         match self {
             Self::FreeVar(fv) if fv.is_linked() => fv.unwrap_linked().try_map_tp(f, tvs),
             Self::FreeVar(fv) => {
-                if let Some(id) = fv.unbound_id() {
-                    if let Some(tv) = tvs.get_tv(id) {
+                if let Some(id) = fv.unbound_id()
+                    && let Some(tv) = tvs.get_tv(id) {
                         return Ok(tv);
                     }
-                }
                 if let Some((sub, sup)) = fv.get_subsup() {
                     fv.dummy_link();
                     let new_sub = sub.clone().try_map_tp(f, tvs)?;

--- a/crates/erg_compiler/ty/typaram.rs
+++ b/crates/erg_compiler/ty/typaram.rs
@@ -1944,11 +1944,10 @@ impl TyParam {
         match self {
             TyParam::FreeVar(fv) if fv.is_linked() => f(fv.unwrap_linked()),
             TyParam::FreeVar(fv) if fv.get_type().is_some() => {
-                if let Some(id) = fv.unbound_id() {
-                    if let Some(tp) = tvs.get_tp(id) {
+                if let Some(id) = fv.unbound_id()
+                    && let Some(tp) = tvs.get_tp(id) {
                         return tp;
                     }
-                }
                 let typ = fv.get_type().unwrap();
                 let new_typ = typ.clone().map_tp(f, tvs);
                 if typ != new_typ {
@@ -2019,11 +2018,10 @@ impl TyParam {
         match self {
             TyParam::FreeVar(fv) if fv.is_linked() => fv.unwrap_linked().map_t(f, tvs),
             TyParam::FreeVar(fv) if fv.get_type().is_some() => {
-                if let Some(id) = fv.unbound_id() {
-                    if let Some(tp) = tvs.get_tp(id) {
+                if let Some(id) = fv.unbound_id()
+                    && let Some(tp) = tvs.get_tp(id) {
                         return tp;
                     }
-                }
                 let typ = fv.get_type().unwrap();
                 let new_typ = f(typ.clone());
                 if typ != new_typ {

--- a/crates/erg_compiler/ty/value.rs
+++ b/crates/erg_compiler/ty/value.rs
@@ -476,7 +476,7 @@ impl TypeObj {
     pub const fn is_inited(&self) -> bool {
         match self {
             Self::Builtin { .. } => true,
-            Self::Generated(gen) => gen.is_inited(),
+            Self::Generated(generator) => generator.is_inited(),
         }
     }
 
@@ -1208,7 +1208,7 @@ impl<'a> TryFrom<&'a ValueObj> for &'a Type {
         match val {
             ValueObj::Type(t) => match t {
                 TypeObj::Builtin { t, .. } => Ok(t),
-                TypeObj::Generated(gen) => Ok(gen.typ()),
+                TypeObj::Generated(generator) => Ok(generator.typ()),
             },
             _ => Err(()),
         }
@@ -1259,8 +1259,8 @@ impl ValueObj {
         })
     }
 
-    pub const fn gen_t(gen: GenTypeObj) -> Self {
-        ValueObj::Type(TypeObj::Generated(gen))
+    pub const fn gen_t(generator: GenTypeObj) -> Self {
+        ValueObj::Type(TypeObj::Generated(generator))
     }
 
     /// closed range (..)
@@ -1873,7 +1873,7 @@ impl ValueObj {
                     log!(err "TODO: {builtin}{attr}");
                     None
                 }
-                TypeObj::Generated(gen) => match gen.typ() {
+                TypeObj::Generated(generator) => match generator.typ() {
                     Type::Record(rec) => {
                         let t = rec.get(attr)?;
                         Some(ValueObj::builtin_type(t.clone()))

--- a/crates/erg_compiler/ty/value.rs
+++ b/crates/erg_compiler/ty/value.rs
@@ -574,6 +574,7 @@ impl TypeObj {
     }
 }
 
+#[allow(clippy::derive_ord_xor_partial_ord)]
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct Float(f64);
 
@@ -584,7 +585,6 @@ impl fmt::Display for Float {
 }
 
 impl Eq for Float {}
-#[allow(clippy::derive_ord_xor_partial_ord)]
 impl Ord for Float {
     fn cmp(&self, other: &Self) -> Ordering {
         self.0.partial_cmp(&other.0).unwrap()

--- a/crates/erg_compiler/ty/value.rs
+++ b/crates/erg_compiler/ty/value.rs
@@ -16,21 +16,21 @@ use erg_common::python_util::PythonVersion;
 use erg_common::serialize::*;
 use erg_common::set::Set;
 use erg_common::traits::LimitedDisplay;
-use erg_common::{dict, fmt_iter, log, switch_lang};
 use erg_common::{ArcArray, Str};
+use erg_common::{dict, fmt_iter, log, switch_lang};
 use erg_parser::ast::{ConstArgs, ConstExpr};
 
-use crate::context::eval::type_from_token_kind;
 use crate::context::Context;
+use crate::context::eval::type_from_token_kind;
 
 use self::value_set::inner_class;
 
-use super::codeobj::{tuple_into_bytes, CodeObj};
+use super::codeobj::{CodeObj, tuple_into_bytes};
 use super::constructors::{dict_t, list_t, refinement, set_t, tuple_t, unsized_list_t};
 use super::free::{Constraint, FreeTyVar, HasLevel};
 use super::typaram::{OpKind, TyParam};
-use super::{ConstSubr, Field, HasType, Predicate, SharedFrees, Type};
 use super::{CONTAINER_OMIT_THRESHOLD, GENERIC_LEVEL, STR_OMIT_THRESHOLD};
+use super::{ConstSubr, Field, HasType, Predicate, SharedFrees, Type};
 
 pub struct EvalValueError {
     pub core: Box<ErrorCore>,
@@ -1585,11 +1585,7 @@ impl ValueObj {
             */
             (_s, _o) => {
                 if let Some(ValueObj::Bool(b)) = _s.clone().try_eq(_o.clone()) {
-                    if b {
-                        Some(Ordering::Equal)
-                    } else {
-                        None
-                    }
+                    if b { Some(Ordering::Equal) } else { None }
                 } else {
                     None
                 }

--- a/crates/erg_linter/lint.rs
+++ b/crates/erg_linter/lint.rs
@@ -165,10 +165,10 @@ impl Linter {
     }
 
     fn lint_tautology(&mut self, expr: &Expr) {
-        if let Expr::BinOp(binop) = expr {
-            if binop.op.kind == TokenKind::GreEq
+        if let Expr::BinOp(binop) = expr
+            && (binop.op.kind == TokenKind::GreEq
                 || binop.op.kind == TokenKind::LessEq
-                || binop.op.kind == TokenKind::DblEq
+                || binop.op.kind == TokenKind::DblEq)
             {
                 let lhs = binop.lhs.as_ref();
                 let rhs = binop.rhs.as_ref();
@@ -182,7 +182,6 @@ impl Linter {
                     ));
                 }
             }
-        }
         self.check_recursively(&Self::lint_tautology, expr);
     }
 
@@ -249,8 +248,7 @@ impl Linter {
                 t: Type::Record(record),
                 ..
             }) = obj.base_or_sup()
-            {
-                if record.len() >= MAX_INSTANCE_ATTRIBUTES {
+                && record.len() >= MAX_INSTANCE_ATTRIBUTES {
                     self.warns.push(too_many_instance_attributes(
                         self.input(),
                         line!() as usize,
@@ -258,7 +256,6 @@ impl Linter {
                         expr.loc(),
                     ));
                 }
-            }
         } else {
             self.check_recursively(&Self::lint_too_many_instance_attributes, expr);
         }

--- a/crates/erg_parser/ast.rs
+++ b/crates/erg_parser/ast.rs
@@ -1150,8 +1150,8 @@ pub struct ListComprehension {
 impl NestedDisplay for ListComprehension {
     fn fmt_nest(&self, f: &mut fmt::Formatter<'_>, _level: usize) -> fmt::Result {
         let mut generators = String::new();
-        for (name, gen) in self.generators.iter() {
-            write!(generators, "{name} <- {gen}; ")?;
+        for (name, generator) in self.generators.iter() {
+            write!(generators, "{name} <- {generator}; ")?;
         }
         write!(
             f,
@@ -1172,8 +1172,8 @@ impl Traversable for ListComprehension {
         if let Some(layout) = &self.layout {
             f(layout);
         }
-        for (_, gen) in &self.generators {
-            f(gen);
+        for (_, generator) in &self.generators {
+            f(generator);
         }
         if let Some(guard) = &self.guard {
             f(guard);
@@ -1385,8 +1385,8 @@ pub struct DictComprehension {
 impl NestedDisplay for DictComprehension {
     fn fmt_nest(&self, f: &mut fmt::Formatter<'_>, _level: usize) -> fmt::Result {
         let mut generators = String::new();
-        for (name, gen) in self.generators.iter() {
-            write!(generators, "{name} <- {gen}; ")?;
+        for (name, generator) in self.generators.iter() {
+            write!(generators, "{name} <- {generator}; ")?;
         }
         write!(
             f,
@@ -1404,8 +1404,8 @@ impl Traversable for DictComprehension {
     type Target = Expr;
     fn traverse(&self, f: &mut impl FnMut(&Self::Target)) {
         self.kv.traverse(f);
-        for (_, gen) in &self.generators {
-            f(gen);
+        for (_, generator) in &self.generators {
+            f(generator);
         }
         if let Some(guard) = &self.guard {
             f(guard);
@@ -1949,8 +1949,8 @@ pub struct SetComprehension {
 impl NestedDisplay for SetComprehension {
     fn fmt_nest(&self, f: &mut fmt::Formatter<'_>, _level: usize) -> fmt::Result {
         let mut generators = String::new();
-        for (name, gen) in self.generators.iter() {
-            write!(generators, "{name} <- {gen}; ")?;
+        for (name, generator) in self.generators.iter() {
+            write!(generators, "{name} <- {generator}; ")?;
         }
         write!(
             f,
@@ -1970,8 +1970,8 @@ impl Traversable for SetComprehension {
         if let Some(layout) = &self.layout {
             f(layout);
         }
-        for (_, gen) in &self.generators {
-            f(gen);
+        for (_, generator) in &self.generators {
+            f(generator);
         }
         if let Some(guard) = &self.guard {
             f(guard);
@@ -2142,7 +2142,7 @@ impl UnaryOp {
     }
 
     pub fn set_value(&mut self, value: Expr) {
-        self.args[0] = Box::new(value);
+        *self.args[0] = value;
     }
 }
 
@@ -2242,7 +2242,7 @@ impl Call {
 
     #[setter]
     pub fn set_obj(&mut self, obj: Expr) {
-        self.obj = Box::new(obj);
+        *self.obj = obj;
     }
 
     #[getter]
@@ -2755,8 +2755,8 @@ pub struct ConstSetComprehension {
 impl NestedDisplay for ConstSetComprehension {
     fn fmt_nest(&self, f: &mut fmt::Formatter<'_>, _level: usize) -> fmt::Result {
         let mut generators = String::new();
-        for (name, gen) in self.generators.iter() {
-            write!(generators, "{name} <- {gen}, ")?;
+        for (name, generator) in self.generators.iter() {
+            write!(generators, "{name} <- {generator}, ")?;
         }
         write!(
             f,
@@ -2799,7 +2799,7 @@ impl ConstSetComprehension {
             self.layout.map(|ex| ex.downgrade()),
             self.generators
                 .into_iter()
-                .map(|(name, gen)| (name, gen.downgrade()))
+                .map(|(name, generator)| (name, generator.downgrade()))
                 .collect(),
             self.guard.map(|ex| ex.downgrade()),
         )

--- a/crates/erg_parser/ast.rs
+++ b/crates/erg_parser/ast.rs
@@ -2083,11 +2083,11 @@ impl BinOp {
     }
 
     pub fn set_lhs(&mut self, lhs: Expr) {
-        self.args[0] = Box::new(lhs);
+        *self.args[0] = lhs;
     }
 
     pub fn set_rhs(&mut self, rhs: Expr) {
-        self.args[1] = Box::new(rhs);
+        *self.args[1] = rhs;
     }
 }
 

--- a/crates/erg_parser/desugar.rs
+++ b/crates/erg_parser/desugar.rs
@@ -211,7 +211,7 @@ impl Desugarer {
                     let generators = lis
                         .generators
                         .into_iter()
-                        .map(|(ident, gen)| (ident, desugar(gen)))
+                        .map(|(ident, generator)| (ident, desugar(generator)))
                         .collect();
                     let guard = lis.guard.map(|ex| desugar(*ex));
                     let lis =
@@ -251,8 +251,8 @@ impl Desugarer {
                 astSet::Comprehension(set) => {
                     let elem = set.layout.map(|ex| desugar(*ex));
                     let mut new_generators = vec![];
-                    for (ident, gen) in set.generators.into_iter() {
-                        new_generators.push((ident, desugar(gen)));
+                    for (ident, generator) in set.generators.into_iter() {
+                        new_generators.push((ident, desugar(generator)));
                     }
                     let new_guard = set.guard.map(|ex| desugar(*ex));
                     let set = SetComprehension::new(
@@ -283,8 +283,8 @@ impl Desugarer {
                     let key = desugar(dic.kv.key);
                     let value = desugar(dic.kv.value);
                     let mut new_generators = vec![];
-                    for (ident, gen) in dic.generators.into_iter() {
-                        new_generators.push((ident, desugar(gen)));
+                    for (ident, generator) in dic.generators.into_iter() {
+                        new_generators.push((ident, desugar(generator)));
                     }
                     let new_guard = dic.guard.map(|ex| desugar(*ex));
                     let dic = DictComprehension::new(

--- a/crates/erg_parser/parse.rs
+++ b/crates/erg_parser/parse.rs
@@ -329,12 +329,12 @@ impl Parser {
         }
     }
 
-    fn unexpected_none(&self, errno: u32, caused_by: &str) -> ParseError {
+    fn unexpected_none(&self, errno: u32, caused_by: String) -> ParseError {
         log!(err "error caused by: {caused_by}");
         ParseError::invalid_none_match(0, Location::Unknown, file!(), errno)
     }
 
-    fn skip_and_throw_syntax_err(&mut self, errno: u32, caused_by: &str) -> ParseError {
+    fn skip_and_throw_syntax_err(&mut self, errno: u32, caused_by: String) -> ParseError {
         let loc = self.peek().map(|t| t.loc()).unwrap_or_default();
         log!(err "error caused by: {caused_by}");
         self.next_expr();
@@ -343,7 +343,7 @@ impl Parser {
 
     fn skip_and_throw_invalid_unclosed_err(
         &mut self,
-        caused_by: &str,
+        caused_by: String,
         line: u32,
         closer: &str,
         ty: &str,
@@ -356,7 +356,7 @@ impl Parser {
 
     fn skip_and_throw_invalid_seq_err(
         &mut self,
-        caused_by: &str,
+        caused_by: String,
         errno: usize,
         expected: &[impl std::fmt::Display],
         found: TokenKind,
@@ -369,7 +369,7 @@ impl Parser {
 
     fn skip_and_throw_invalid_chunk_err(
         &mut self,
-        caused_by: &str,
+        caused_by: String,
         line: u32,
         loc: Location,
     ) -> ParseError {
@@ -382,7 +382,7 @@ impl Parser {
         &mut self,
         errno: usize,
         loc: Location,
-        caused_by: &str,
+        caused_by: String,
     ) -> ParseError {
         log!(err "error caused by: {caused_by}");
         self.next_expr();

--- a/crates/erg_parser/typespec.rs
+++ b/crates/erg_parser/typespec.rs
@@ -69,8 +69,8 @@ impl Parser {
                         .map(|ex| Self::validate_const_expr(*ex))
                         .transpose()?;
                     let mut generators = vec![];
-                    for (name, gen) in set.generators.into_iter() {
-                        let pred = Self::validate_const_expr(gen)?;
+                    for (name, generator) in set.generators.into_iter() {
+                        let pred = Self::validate_const_expr(generator)?;
                         generators.push((name, pred));
                     }
                     let guard = set

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -13,8 +13,8 @@ use erg_common::traits::{BlockKind, ExitStatus, New, Runnable};
 use erg_compiler::hir::Expr;
 use erg_compiler::ty::HasType;
 
-use erg_compiler::error::{CompileError, CompileErrors};
 use erg_compiler::Compiler;
+use erg_compiler::error::{CompileError, CompileErrors};
 use erg_parser::ParserRunner;
 
 pub type EvalError = CompileError;
@@ -442,7 +442,9 @@ impl PackageManagerRunner {
 
     pub fn run(cfg: ErgConfig) -> ExitStatus {
         if Command::new("poise").arg("--version").output().is_err() {
-            eprintln!("Error: poise is not installed. Please install using ergup or manually from the repository (https://github.com/erg-lang/poise).");
+            eprintln!(
+                "Error: poise is not installed. Please install using ergup or manually from the repository (https://github.com/erg-lang/poise)."
+            );
             return ExitStatus::ERR1;
         }
         match Command::new("poise")


### PR DESCRIPTION
This is a brief description.

Change the edition and fix the warnings that occurred.

- use `let chains`
- avoid using the reserved kw `gen`
- other
    - auto format
    - avoiding unnecessary allocations
    - existing unsafe specification